### PR TITLE
Add scoped discovery

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
     description: "Throttle limit used in Foreach-Object -Parallel for resource/subscription discovery"
     required: false
     default: "10"
+  azops_discovery_scope:
+    description: "Limit discovery to the specified management group resource ID. Must also be used with azops_ignore_context_check=1"
+    required: false
   github_email:
     description: "Git Email"
     required: false


### PR DESCRIPTION
The customer @liamfoneill and I are working with has a large Azure estate that they do not want to manage with AzOps

To avoid the risk of accidentally deploying resources to the legacy estate, a scoped discovery option is one key element in meeting this requirement. The other is reduced RBAC role at tenant root, this is a separate discussion.

We have implemented this for them as a fork but it would be great for this to be upstream as well.

Also referencing @krnese, @victorar & @hjscherer  who were on the customer call 