### PR TITLE
Removed duplicate timestamps

### DIFF
--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -120,7 +120,7 @@ function Initialize-AzOpsGlobalVariables {
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup
-            Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Global Variable AzOpsState or AzOpsAzManagementGroup is not Initialized. Initializing it now $(get-Date)"
+            Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Global Variable AzOpsState or AzOpsAzManagementGroup is not Initialized. Initializing it now"
             # Get all managementgroups that principal has access to
             $global:AzOpsPartialRoot = @()
             # Initialize global variable for Management Groups
@@ -146,7 +146,7 @@ function Initialize-AzOpsGlobalVariables {
                 }
                 $global:AzOpsAzManagementGroup = $global:AzOpsAzManagementGroup | Sort-Object -Property Id -Unique
 
-                Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Global Variable AzOpsState or AzOpsAzManagementGroup is initialized $(Get-Date)"
+                Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Global Variable AzOpsState or AzOpsAzManagementGroup is initialized"
 
             }
             else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes.
-->

**This PR fixes**

Removes duplicate timestamp logging, AzOpsLog includes timestamp at the start of the output.

_VERBOSE: [2020-07-17 10:45:08.1945] (Initialize-AzOpsGlobalVariables) Global Variable AzOpsState or AzOpsAzManagementGroup is not Initialized. Initializing it now 07/17/2020 11:45:08_

_VERBOSE: [2020-07-17 10:45:08.1945] (Initialize-AzOpsGlobalVariables) Global Variable AzOpsState or AzOpsAzManagementGroup is not Initialized. Initializing it now_