### PR TITLE
Updated Az target version, Subscription exclusion through QuotaID

### DIFF
--- a/.azure-pipelines/ubuntu-latest.yml
+++ b/.azure-pipelines/ubuntu-latest.yml
@@ -1,12 +1,12 @@
 pr:
   paths:
     include:
-      - "*"
+      - '*'
     exclude:
       - .github/*
       - .vscode/*
       - docs/*
-      - "*.md"
+      - '*.md'
 
 variables:
   DEFAULT_JOB_TIMEOUT_IN_MINUTES: 30

--- a/.azure-pipelines/ubuntu-latest.yml
+++ b/.azure-pipelines/ubuntu-latest.yml
@@ -1,17 +1,17 @@
 pr:
   paths:
     include:
-      - '*'
+      - "*"
     exclude:
       - .github/*
       - .vscode/*
       - docs/*
-      - '*.md'
+      - "*.md"
 
 variables:
   DEFAULT_JOB_TIMEOUT_IN_MINUTES: 30
-  AZ_ACCOUNTS_REQUIRED_VERSION: "1.8.0"
-  AZ_RESOURCES_REQUIRED_VERSION: "2.0.1"
+  AZ_ACCOUNTS_REQUIRED_VERSION: "1.9.1"
+  AZ_RESOURCES_REQUIRED_VERSION: "2.3.0"
   PESTER_REQUIRED_VERSION: "5.0.2"
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ LABEL repository="https://github.com/Azure/AzOps"
 LABEL maintainer="Microsoft"
 
 ARG github=0.10.0
-ARG azure_accounts=1.8.1
-ARG azure_resources=2.0.1
+ARG azure_accounts=1.9.1
+ARG azure_resources=2.3.0
 
 RUN [ "/bin/bash", "-c", "apt-get update &> /dev/null && apt-get install -y git wget &> /dev/null" ]
 RUN [ "/bin/bash", "-c", "wget https://github.com/cli/cli/releases/download/v${github}/gh_${github}_linux_amd64.deb -O /tmp/gh_${github}_linux_amd64.deb  &> /dev/null" ]

--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -52,8 +52,8 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @("Az.Accounts", @{ ModuleName = "Az.Accounts"; ModuleVersion = "1.8.0" } )
-        @("Az.Resources", @{ ModuleName = "Az.Resources"; ModuleVersion = "2.0.1" } )
+        @("Az.Accounts", @{ ModuleName = "Az.Accounts"; ModuleVersion = "1.9.1" } )
+        @("Az.Resources", @{ ModuleName = "Az.Resources"; ModuleVersion = "2.3.0" } )
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/src/AzOps.psm1
+++ b/src/AzOps.psm1
@@ -403,10 +403,10 @@ class AzOpsScope {
         if ($this.scope -imatch $this.regex_subscriptionExtract) {
 
             $subId = ((($this.scope -split $this.regex_subscriptionExtract) -split '/') | Where-Object { $_ } | Select-Object -First 1)
-            $sub = $global:AzOpsSubscriptions | Where-Object { $_.Id -eq $subId }
+            $sub = $global:AzOpsSubscriptions | Where-Object { $_.subscriptionId -eq $subId }
             if ($sub) {
                 Write-AzOpsLog -Level Debug -Topic "AzOpsScope" -Message "SubscriptionId found in Azure: $($sub.Id)"
-                return $sub.Id
+                return $sub.subscriptionId
             }
             else {
                 Write-AzOpsLog -Level Warning -Topic "AzOpsScope" -Message "SubscriptionId not found in Azure. Using directory name instead: $($subId)"
@@ -419,10 +419,10 @@ class AzOpsScope {
         if ($this.scope -imatch $this.regex_subscriptionExtract) {
 
             $subId = ((($this.scope -split $this.regex_subscriptionExtract) -split '/') | Where-Object { $_ } | Select-Object -First 1)
-            $sub = $global:AzOpsSubscriptions | Where-Object { $_.Id -eq $subId }
+            $sub = $global:AzOpsSubscriptions | Where-Object { $_.subscriptionId -eq $subId }
             if ($sub) {
-                Write-AzOpsLog -Level Debug -Topic "AzOpsScope" -Message "Subscription DisplayName found in Azure: $($sub.Name)"
-                return $sub.Name
+                Write-AzOpsLog -Level Debug -Topic "AzOpsScope" -Message "Subscription DisplayName found in Azure: $($sub.displayName)"
+                return $sub.displayName
             }
             else {
                 Write-AzOpsLog -Level Warning -Topic "AzOpsScope" -Message "Subscription DisplayName not found in Azure. Using directory name instead: $($subId)"

--- a/src/private/ConvertTo-AzOpsState.ps1
+++ b/src/private/ConvertTo-AzOpsState.ps1
@@ -170,6 +170,7 @@ function ConvertTo-AzOpsState {
         # Load default properties to exclude if defined
         if ("excludedProperties" -in $ResourceConfig.Keys) {
             $ExcludedProperties = $ResourceConfig.excludedProperties.default
+            Write-AzOpsLog -Level Verbose -Topic "ConvertTo-AzOpsState" -Message "Default excluded properties: [$(($ExcludedProperties.Keys -join ','))]"
         }
 
         Write-AzOpsLog -Level Debug -Topic "ConvertTo-AzOpsState" -Message "Statepath is $objectFilePath"
@@ -192,13 +193,14 @@ function ConvertTo-AzOpsState {
             }
 
             # Check if Resource has to be generalized
-            if ($env:GeneralizeTemplates -eq 1) {
+            if ($global:AzOpsGeneralizeTemplates -eq 1) {
                 # Preserve Original Template before manipulating anything
                 # Only export original resource if generalize excluded properties exist
                 if ("excludedProperties" -in $ResourceConfig.Keys) {
                     # Set excludedproperties variable to generalize instead of default
                     $ExcludedProperties = ''
                     $ExcludedProperties = $ResourceConfig.excludedProperties.generalize
+                    Write-AzOpsLog -Level Verbose -Topic "ConvertTo-AzOpsState" -Message "GeneralizeTemplates used: Excluded properties: [$(($ExcludedProperties.Keys -join ','))]"
                     # Export preserved file
                     if ($objectFilePath) {
                         $parametersJson.parameters.input.value = $object
@@ -261,7 +263,7 @@ function ConvertTo-AzOpsState {
             if ('orderObject' -in $ResourceConfig) {
                 $object = ConvertTo-AzOpsObject -InputObject $object -OrderObject
             }
-            if ($env:ExportRawTemplate -eq 1 -or $PSBoundParameters["ExportRawTemplate"]) {
+            if ($global:AzOpsExportRawTemplate -eq 1 -or $PSBoundParameters["ExportRawTemplate"]) {
                 if ($ReturnObject) {
                     # Return resource as object
                     Write-Output -InputObject $object

--- a/src/private/Get-AzOpsAllSubscription.ps1
+++ b/src/private/Get-AzOpsAllSubscription.ps1
@@ -9,6 +9,8 @@
     Subscription offers to exclude
 .PARAMETER ExcludedStates
     Subscription states to exclude
+.PARAMETER TenantId
+    TenantId to query
 .PARAMETER ApiVersion
     API Version to use for the subscription API
 .OUTPUTS
@@ -21,6 +23,9 @@ function Get-AzOpsAllSubscription {
         [string[]]$ExcludedOffers = @('AzurePass_2014-09-01', 'FreeTrial_2014-09-01', 'AAD_2015-09-01'),
         [Parameter(Mandatory = $false)]
         [string[]]$ExcludedStates = @('Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue'),
+        [Parameter(Mandatory = $true)]
+        [ValidateScript( { $_ -in (Get-AzContext).Tenant.Id } )]
+        [guid]$TenantId,
         [Parameter(Mandatory = $false)]
         [string]$ApiVersion = '2020-01-01'
     )
@@ -33,7 +38,7 @@ function Get-AzOpsAllSubscription {
         Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsAllSubscription" -Message "Excluded subscription states are: $(($ExcludedStates -join ','))"
         Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsAllSubscription" -Message "Excluded subscription offers are: $(($ExcludedOffers -join ','))"
         # Get all subscriptions and exclude states/offers
-        $AllSubscriptions = ((Invoke-AzRestMethod -Path /subscriptions?api-version=$ApiVersion -Method GET).Content | ConvertFrom-Json -Depth 100).Value | Where-Object { $_.state -notin $ExcludedStates -and $_.subscriptionPolicies.quotaId -notin $ExcludedOffers }
+        $AllSubscriptions = ((Invoke-AzRestMethod -Path /subscriptions?api-version=$ApiVersion -Method GET).Content | ConvertFrom-Json -Depth 100).Value | Where-Object { $_.state -notin $ExcludedStates -and $_.subscriptionPolicies.quotaId -notin $ExcludedOffers -and $_.tenantId -eq $TenantId }
         if ($null -eq $AllSubscriptions) {
             Write-AzOpsLog -Level Error -Topic "Get-AzOpsAllSubscription" -Message "Found [$($AllSubscriptions.count)] subscriptions - do you have permissions to any subscriptions?"
         }

--- a/src/private/Get-AzOpsAllSubscription.ps1
+++ b/src/private/Get-AzOpsAllSubscription.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    The cmdlet will return all subscriptions in current AzContext excluding the offers and states provided in input parameters.
+.DESCRIPTION
+    The cmdlet will return all subscriptions in current AzContext excluding the offers and states provided in input parameters.
+.EXAMPLE
+    Get-AzOpsAllSubscription
+.PARAMETER ExcludedOffers
+    Subscription offers to exclude
+.PARAMETER ExcludedStates
+    Subscription states to exclude
+.PARAMETER ApiVersion
+    API Version to use for the subscription API
+.OUTPUTS
+    System.Management.Automation.PSCustomObject
+#>
+function Get-AzOpsAllSubscription {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExcludedOffers = @('AzurePass_2014-09-01', 'FreeTrial_2014-09-01', 'AAD_2015-09-01'),
+        [Parameter(Mandatory = $false)]
+        [string[]]$ExcludedStates = @('Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue'),
+        [Parameter(Mandatory = $false)]
+        [string]$ApiVersion = '2020-01-01'
+    )
+    begin {
+        Write-AzOpsLog -Level Debug -Topic "Get-AzOpsAllSubscription" -Message ("Initiating function " + $MyInvocation.MyCommand + " begin")
+    }
+    process {
+        Write-AzOpsLog -Level Debug -Topic "Get-AzOpsAllSubscription" -Message ("Initiating function " + $MyInvocation.MyCommand + " process")
+
+        Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsAllSubscription" -Message "Excluded subscription states are: $(($ExcludedStates -join ','))"
+        Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsAllSubscription" -Message "Excluded subscription offers are: $(($ExcludedOffers -join ','))"
+        # Get all subscriptions and exclude states/offers
+        $AllSubscriptions = ((Invoke-AzRestMethod -Path /subscriptions?api-version=$ApiVersion -Method GET).Content | ConvertFrom-Json -Depth 100).Value | Where-Object { $_.state -notin $ExcludedStates -and $_.subscriptionPolicies.quotaId -notin $ExcludedOffers }
+        if ($null -eq $AllSubscriptions) {
+            Write-AzOpsLog -Level Error -Topic "Get-AzOpsAllSubscription" -Message "Found [$($AllSubscriptions.count)] subscriptions - do you have permissions to any subscriptions?"
+        }
+        else {
+            Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsAllSubscription" -Message "Found [$($AllSubscriptions.count)] subscriptions"
+        }
+
+    }
+    end {
+        Write-AzOpsLog -Level Debug -Topic "Get-AzOpsAllSubscription" -Message ("Initiating function " + $MyInvocation.MyCommand + " end")
+        return $AllSubscriptions
+    }
+}
+

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -114,7 +114,7 @@ function Initialize-AzOpsGlobalVariables {
             $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID  | Where-Object { $_.State -notin 'Disabled', 'Deleted', 'Warned', 'Expired', 'Past Due' }
+            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID  | Where-Object { $_.State -notin 'Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue' }
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -122,7 +122,7 @@ function Initialize-AzOpsGlobalVariables {
             $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $global:AzOpsSubscription = Get-AzOpsAllSubscription -ExcludedOffers $global:AzOpsExcludedSubOffer -ExcludedStates $global:AzOpsExcludedSubState
+            $global:AzOpsSubscriptions = Get-AzOpsAllSubscription -ExcludedOffers $global:AzOpsExcludedSubOffer -ExcludedStates $global:AzOpsExcludedSubState
             #$global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID | Where-Object { $_.State -notin $ExcludedState -and $_.Name -notin $ExcludedPatterns }
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -114,7 +114,9 @@ function Initialize-AzOpsGlobalVariables {
             $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID  | Where-Object { $_.State -notin 'Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue' }
+            $ExcludedPatterns = @('Access to Azure Active Directory')
+            $ExcludedState = ('Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue')
+            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID | Where-Object { $_.State -notin $ExcludedState -and $_.Name -notin $ExcludedPatterns }
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -114,7 +114,7 @@ function Initialize-AzOpsGlobalVariables {
             $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID
+            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID  | Where-Object { $_.State -notin 'Disabled', 'Deleted', 'Warned', 'Expired', 'Past Due' }
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -117,13 +117,12 @@ function Initialize-AzOpsGlobalVariables {
         # Get all subscriptions and Management Groups if InvalidateCache is set to 1 or if the variables are not set
         if ($global:AzOpsInvalidateCache -eq 1 -or $global:AzOpsAzManagementGroup.count -eq 0 -or $global:AzOpsSubscriptions.Count -eq 0) {
             #Get current tenant id
-            $TenantID = (Get-AzContext).Tenant.Id
+            $TenantId = (Get-AzContext).Tenant.Id
             # Set root scope variable basd on tenantid to be able to validate tenant root access if partial discovery is not enabled
-            $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
+            $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantId
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $global:AzOpsSubscriptions = Get-AzOpsAllSubscription -ExcludedOffers $global:AzOpsExcludedSubOffer -ExcludedStates $global:AzOpsExcludedSubState
-            #$global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID | Where-Object { $_.State -notin $ExcludedState -and $_.Name -notin $ExcludedPatterns }
+            $global:AzOpsSubscriptions = Get-AzOpsAllSubscription -ExcludedOffers $global:AzOpsExcludedSubOffer -ExcludedStates $global:AzOpsExcludedSubState -TenantId $TenantId
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -49,8 +49,8 @@ function Initialize-AzOpsGlobalVariables {
             AZOPS_MAIN_TEMPLATE                = @{ AzOpsMainTemplate = "$PSScriptRoot\..\..\template\template.json" } # Main template json
             AZOPS_STATE_CONFIG                 = @{ AzOpsStateConfig = "$PSScriptRoot\..\AzOpsStateConfig.json" } # Configuration file for resource serialization
             AZOPS_ENROLLMENT_PRINCIPAL_NAME    = @{ AzOpsEnrollmentAccountPrincipalName = $null }
-            AZOPS_EXCLUDED_SUB_OFFER           = @{ AzOpsExcludedSubOffer = "AzurePass_2014-09-01,FreeTrial_2014-09-01,AAD_2015-09-01" }
-            AZOPS_EXCLUDED_SUB_STATE           = @{ AzOpsExcludedSubState = "Disabled,Deleted,Warned,Expired,PastDue" }
+            AZOPS_EXCLUDED_SUB_OFFER           = @{ AzOpsExcludedSubOffer = "AzurePass_2014-09-01,FreeTrial_2014-09-01,AAD_2015-09-01" } # Excluded QuotaIDs as per https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers
+            AZOPS_EXCLUDED_SUB_STATE           = @{ AzOpsExcludedSubState = "Disabled,Deleted,Warned,Expired,PastDue" } # Excluded subscription states as per https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list#subscriptionstate
             AZOPS_OFFER_TYPE                   = @{ AzOpsOfferType = 'MS-AZR-0017P' }
             AZOPS_DEFAULT_DEPLOYMENT_REGION    = @{ AzOpsDefaultDeploymentRegion = 'northeurope' } # Default deployment region for state deployments (ARM region, not region where a resource is deployed)
             AZOPS_INVALIDATE_CACHE             = @{ AzOpsInvalidateCache = 1 } # Invalidates cache and ensures that Management Groups and Subscriptions are re-discovered

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -26,6 +26,8 @@ function Initialize-AzOpsGlobalVariables {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:AzOpsState')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:AzOpsSupportPartialMgDiscovery')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:AzOpsPartialMgDiscoveryRoot')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:AzOpsExcludedSubOffer')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', 'global:AzOpsExcludedSubState')]
     [CmdletBinding()]
     [OutputType()]
     param (
@@ -47,6 +49,8 @@ function Initialize-AzOpsGlobalVariables {
             AZOPS_MAIN_TEMPLATE                = @{ AzOpsMainTemplate = "$PSScriptRoot\..\..\template\template.json" } # Main template json
             AZOPS_STATE_CONFIG                 = @{ AzOpsStateConfig = "$PSScriptRoot\..\AzOpsStateConfig.json" } # Configuration file for resource serialization
             AZOPS_ENROLLMENT_PRINCIPAL_NAME    = @{ AzOpsEnrollmentAccountPrincipalName = $null }
+            AZOPS_EXCLUDED_SUB_OFFER           = @{ AzOpsExcludedSubOffer = "AzurePass_2014-09-01,FreeTrial_2014-09-01,AAD_2015-09-01" }
+            AZOPS_EXCLUDED_SUB_STATE           = @{ AzOpsExcludedSubState = "Disabled,Deleted,Warned,Expired,PastDue" }
             AZOPS_OFFER_TYPE                   = @{ AzOpsOfferType = 'MS-AZR-0017P' }
             AZOPS_DEFAULT_DEPLOYMENT_REGION    = @{ AzOpsDefaultDeploymentRegion = 'northeurope' } # Default deployment region for state deployments (ARM region, not region where a resource is deployed)
             AZOPS_INVALIDATE_CACHE             = @{ AzOpsInvalidateCache = 1 } # Invalidates cache and ensures that Management Groups and Subscriptions are re-discovered
@@ -79,6 +83,10 @@ function Initialize-AzOpsGlobalVariables {
                 # Set global variables for script
                 $GlobalVar = $AzOpsEnvVariables["$AzOpsEnv"].Keys
                 Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Setting global variable $GlobalVar to $EnvVarValue"
+                # Convert comma separated vars to array (since all env vars are strings)
+                if ($EnvVarValue -match ',') {
+                    $EnvVarValue = $EnvVarValue -split ','
+                }
                 Set-Variable -Name $GlobalVar -Scope Global -Value $EnvvarValue
             }
         }
@@ -114,9 +122,8 @@ function Initialize-AzOpsGlobalVariables {
             $RootScope = '/providers/Microsoft.Management/managementGroups/{0}' -f $TenantID
             # Initialize global variable for subscriptions - get all subscriptions in Tenant
             Write-AzOpsLog -Level Verbose -Topic "Initialize-AzOpsGlobalVariables" -Message "Initializing Global Variable AzOpsSubscriptions"
-            $ExcludedPatterns = @('Access to Azure Active Directory')
-            $ExcludedState = ('Disabled', 'Deleted', 'Warned', 'Expired', 'PastDue')
-            $global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID | Where-Object { $_.State -notin $ExcludedState -and $_.Name -notin $ExcludedPatterns }
+            $global:AzOpsSubscription = Get-AzOpsAllSubscription -ExcludedOffers $global:AzOpsExcludedSubOffer -ExcludedStates $global:AzOpsExcludedSubState
+            #$global:AzOpsSubscriptions = Get-AzSubscription -TenantId $TenantID | Where-Object { $_.State -notin $ExcludedState -and $_.Name -notin $ExcludedPatterns }
             # Initialize global variable for Management Groups
             $global:AzOpsAzManagementGroup = @()
             # Initialize global variable for partial root discovery that will be set in AzOpsAllManagementGroup


### PR DESCRIPTION
- New Az PowerShell target versions in codebase, tests and action
   - Az.Accounts **(1.9.1)**
   - Az.Resources **(2.3.0)**
- Switched from Get-AzSubscription to Invoke-AzRestMethod for subscription discovery to be able to filter on subscription QuotaId
