### PR TITLE
Feature - Disabling properties bag creation in <managementgroup>.json and <subscription>.json to avoid duplication

### DIFF
--- a/src/private/Get-AzOpsAllManagementGroup.ps1
+++ b/src/private/Get-AzOpsAllManagementGroup.ps1
@@ -41,7 +41,7 @@ function Get-AzOpsAllManagementGroup {
 
     }
     process {
-        $MG = Get-AzManagementGroup -GroupId $ManagementGroup -Expand -Recurse -WarningAction SilentlyContinue
+        $MG = Get-AzManagementGroup -GroupId $ManagementGroup -Expand -WarningAction SilentlyContinue
         if (1 -eq $global:AzOpsSupportPartialMgDiscovery -or -not ($Global:AzOpsTenantRootPermissions)) {
             if ($MG.ParentId -and -not(Get-AzManagementGroup -GroupId $MG.ParentName -ErrorAction Ignore -WarningAction SilentlyContinue)) {
                 $global:AzOpsPartialRoot += $MG

--- a/src/private/Get-AzOpsResourceDefinitionAtScope.ps1
+++ b/src/private/Get-AzOpsResourceDefinitionAtScope.ps1
@@ -337,23 +337,26 @@ function Get-AzOpsResourceDefinitionAtScope {
                         $serializedRoleAssignmentInAzure += ConvertTo-AzOpsState -Resource $roleAssignment -ReturnObject -ExportRawTemplate
                     }
                 }
+                #
+                # Disabling properties bag creation in <managementgroup>.json and <subscription>.json to avoid code duplication.
+                #
                 # For subscriptions and Management Groups, export all policy/policyset/policyassignments at scope in one file
-                if ($scope.Type -in 'subscriptions', 'managementgroups') {
-                    # Get statefile from scope
-                    $parametersJson = Get-Content -Path $scope.statepath | ConvertFrom-Json -Depth 100
-                    # Create property bag and add resources at scope
-                    $propertyBag = [ordered]@{
-                        'policyDefinitions'    = @($serializedPolicyDefinitionsInAzure)
-                        'policySetDefinitions' = @($serializedPolicySetDefinitionsInAzure)
-                        'policyAssignments'    = @($serializedPolicyAssignmentsInAzure)
-                        'roleDefinitions'      = @($serializedRoleDefinitionsInAzure)
-                        'roleAssignments'      = if ($global:AzOpsGeneralizeTemplates -eq 1) { , @() } else { , @($serializedRoleAssignmentInAzure) }
-                    }
-                    # Add property bag to parameters json
-                    $parametersJson.parameters.input.value | Add-Member -Name 'properties' -Type NoteProperty -Value $propertyBag -force
-                    # Export state file with properties at scope
-                    ConvertTo-AzOpsState -Resource $parametersJson -ExportPath $scope.statepath -ExportRawTemplate
-                }
+                # if ($scope.Type -in 'subscriptions', 'managementgroups') {
+                #     # Get statefile from scope
+                #     $parametersJson = Get-Content -Path $scope.statepath | ConvertFrom-Json -Depth 100
+                #     # Create property bag and add resources at scope
+                #     $propertyBag = [ordered]@{
+                #         'policyDefinitions'    = @($serializedPolicyDefinitionsInAzure)
+                #         'policySetDefinitions' = @($serializedPolicySetDefinitionsInAzure)
+                #         'policyAssignments'    = @($serializedPolicyAssignmentsInAzure)
+                #         'roleDefinitions'      = @($serializedRoleDefinitionsInAzure)
+                #         'roleAssignments'      = if ($global:AzOpsGeneralizeTemplates -eq 1) { , @() } else { , @($serializedRoleAssignmentInAzure) }
+                #     }
+                #     # Add property bag to parameters json
+                #     $parametersJson.parameters.input.value | Add-Member -Name 'properties' -Type NoteProperty -Value $propertyBag -force
+                #     # Export state file with properties at scope
+                #     ConvertTo-AzOpsState -Resource $parametersJson -ExportPath $scope.statepath -ExportRawTemplate
+                # }
             }
             Write-AzOpsLog -Level Verbose -Topic "Get-AzOpsResourceDefinitionAtScope" -Message "Finished Processing Scope [$($scope.scope)]"
         }

--- a/src/public/Initialize-AzOpsGlobalVariables.ps1
+++ b/src/public/Initialize-AzOpsGlobalVariables.ps1
@@ -173,7 +173,7 @@ function Initialize-AzOpsGlobalVariables {
                         # Add for recursive discovery
                         $ManagementGroups += [pscustomobject]@{ Name = $_ }
                         # Add user provided root to partial root variable to know where discovery should start
-                        $global:AzOpsPartialRoot += Get-AzManagementGroup -GroupId $_ -Recurse -Expand -WarningAction SilentlyContinue
+                        $global:AzOpsPartialRoot += Get-AzManagementGroup -GroupId $_ -Expand -WarningAction SilentlyContinue
                     }
                 }
                 # If permissions exist at tenant root management group, filter out directly assigned permissions further down in the hierarchy to improve performance


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes.
-->

**This PR fixes**

Feature - Disabling properties bag creation in ```<managementgroup>.json``` and ```<subscription>.json```  to avoid duplication

Breaking change

- ```<managementgroup>.json``` and ```<subscription>.json``` will only have immediate child instead of  (n) depth of management group and subscriptions. This will ensure when leaf node changes (add/delete/move), it will not trigger change all the up to the root

-  properties bag in <managementgroup>.json and <subscription>.json is removed to ensure all artefacts are represented only once in repo (avoiding duplication of  ARM templates and reducing the file length). This will ensure each resource have its own lifecycle in Git and can be managed independently.