### PR TITLE
Replace grep with PowerShell Select-String

### DIFF
--- a/src/public/Invoke-AzOpsGitPull.ps1
+++ b/src/public/Invoke-AzOpsGitPull.ps1
@@ -33,7 +33,7 @@ function Invoke-AzOpsGitPull {
 
         Write-AzOpsLog -Level Information -Topic "git" -Message "Checking for branch (system)"
         $branch = Start-AzOpsNativeExecution {
-            git branch --remote | grep 'origin/system'
+            git branch --remote | Select-String 'origin/system'
         } -IgnoreExitcode
 
         if ($branch) {


### PR DESCRIPTION
`Invoke-AzOpsGitPull` uses `grep` for verifying the remote existence. This is not available in Windows so debugging locally fails for "grep is missing". This can be simply replaced with PowerShell `Select-String`. This improves local development experience.