### PR TITLE
[Enhancement] Removing duplicate code in switch statement

### DIFF
--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'AzOps.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.1'
+    ModuleVersion     = '1.0.2'
 
     # ID used to uniquely identify this module
     GUID              = '4336cc9b-48f8-4b0e-9629-fd1245e848d9'

--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'AzOps.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.2'
+    ModuleVersion     = '1.0.4'
 
     # ID used to uniquely identify this module
     GUID              = '4336cc9b-48f8-4b0e-9629-fd1245e848d9'

--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'AzOps.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.2'
+    ModuleVersion     = '1.0.3'
 
     # ID used to uniquely identify this module
     GUID              = '4336cc9b-48f8-4b0e-9629-fd1245e848d9'

--- a/src/internal/classes/AzOpsScope.ps1
+++ b/src/internal/classes/AzOpsScope.ps1
@@ -133,79 +133,79 @@
         }
         else {
             $resourcePath = Get-Content $Path | ConvertFrom-Json -AsHashtable
-            if ($resourcePath) {
-                switch ($resourcePath) {
-                    { $_.parameters.input.value.Keys -contains "ResourceId" } {
-                        # Parameter Files - resource from parameters file
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.ResourceId' -StringValues $($resourcePath.parameters.input.value.ResourceId) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $this.InitializeMemberVariables($resourcePath.parameters.input.value.ResourceId)
-                        break
-                    }
-                    { $_.parameters.input.value.Keys -contains "Id" } {
-                        # Parameter Files - ManagementGroup and Subscription
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.Id' -StringValues $($resourcePath.parameters.input.value.Id) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $this.InitializeMemberVariables($resourcePath.parameters.input.value.Id)
-                        break
-                    }
-                    { $_.parameters.input.value.Keys -contains "Type" } {
-                        # Parameter Files - Determine Resource Type and Name (Management group)
-                        # Management group resource id do contain '/provider'
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.Type' -StringValues ("$($resourcePath.parameters.input.value.Type)/$($resourcePath.parameters.input.value.Name)") -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $this.InitializeMemberVariables("$($resourcePath.parameters.input.value.Type)/$($resourcePath.parameters.input.value.Name)")
-                        break
-                    }
-                    { $_.parameters.input.value.Keys -contains "ResourceType" } {
-                        # Parameter Files - Determine Resource Type and Name (Any ResourceType except management group)
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.ResourceType' -StringValues ($resourcePath.parameters.input.value.ResourceType) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $currentScope = New-AzOpsScope -Path ($Path.Directory)
 
-                        # Creating Resource Id based on current scope, resource Type and Name of the resource
-                        $this.InitializeMemberVariables("$($currentScope.scope)/providers/$($resourcePath.parameters.input.value.ResourceType)/$($resourcePath.parameters.input.value.Name)")
-                        break
-                    }
-                    { $_.resources -and
-                        $_.resources[0].type -eq 'Microsoft.Management/managementGroups' } {
-                        # Template - Management Group
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.managementgroups' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $this.InitializeMemberVariables("/providers/Microsoft.Management/managementgroups/{0}" -f ($_.resources[0].name) )
-                        break
-                    }
-                    { $_.resources -and
-                        $_.resources[0].type -eq 'Microsoft.Management/managementGroups/subscriptions' } {
-                        # Template - Subscription
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.subscriptions' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $this.InitializeMemberVariables("/subscriptions/{0}" -f ($_.resources[0].name -split '/' | Select-Object -Last 1) )
-                        break
-                    }
-                    { $_.resources -and
-                        $_.resources[0].type -eq 'Microsoft.Resources/resourceGroups' } {
-                        Write-PSFMessage -Level Verbose -String 'Az OpsScope.InitializeMemberVariablesFromFile.resourceGroups' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        #Get the name of subscription from parent scope
-                        $currentScope = New-AzOpsScope -Path ($Path.Directory.Parent)
-
-                        #Initialize resource group
-                        $this.InitializeMemberVariables("$($currentScope.scope)/resourceGroups/{0}" -f $_.resources[0].name )
-                        break
-                    }
-                    { $_.resources } {
-                        # Template - 1st resource
-                        Write-PSFMessage -Level Verbose -String 'Az OpsScope.InitializeMemberVariablesFromFile.resource' -StringValues ($_.resources[0].type), ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
-                        $currentScope = New-AzOpsScope -Path ($Path.Directory)
-                        $this.InitializeMemberVariables("$($currentScope.scope)/providers/$($_.resources[0].type)/$($_.resources[0].name)")
-                        break
-                    }
-                    Default {
-                        Write-PSFMessage -Level Warning  -String 'AzOpsScope.Input.BadData.TemplateParameterFile' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
-                        Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromDirectory' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
-                        $this.InitializeMemberVariablesFromDirectory($Path.Directory)
-                    }
-                }
+            if (!$resourcePath) {
+                # Empty file with .json is not valid JSON file. Empty Json should've minimum file content '{}'
+                # However, due to bug that is combination of Get-Content and ConvertFrom-Json when empty file with .json (that is valid file but not valid Json),
+                # switch statement is failing to handle $null value unless assigned explicitly.
+                $resourcePath = $null
             }
-            else {
-                # if input Json is not valid resource template or parameter file
-                Write-PSFMessage -Level Warning  -String 'AzOpsScope.Input.BadData.TemplateParameterFile' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
-                Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromDirectory' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
-                $this.InitializeMemberVariablesFromDirectory($Path.Directory)
+
+            switch ($resourcePath) {
+                { $_.parameters.input.value.Keys -contains "ResourceId" } {
+                    # Parameter Files - resource from parameters file
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.ResourceId' -StringValues $($resourcePath.parameters.input.value.ResourceId) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $this.InitializeMemberVariables($resourcePath.parameters.input.value.ResourceId)
+                    break
+                }
+                { $_.parameters.input.value.Keys -contains "Id" } {
+                    # Parameter Files - ManagementGroup and Subscription
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.Id' -StringValues $($resourcePath.parameters.input.value.Id) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $this.InitializeMemberVariables($resourcePath.parameters.input.value.Id)
+                    break
+                }
+                { $_.parameters.input.value.Keys -contains "Type" } {
+                    # Parameter Files - Determine Resource Type and Name (Management group)
+                    # Management group resource id do contain '/provider'
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.Type' -StringValues ("$($resourcePath.parameters.input.value.Type)/$($resourcePath.parameters.input.value.Name)") -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $this.InitializeMemberVariables("$($resourcePath.parameters.input.value.Type)/$($resourcePath.parameters.input.value.Name)")
+                    break
+                }
+                { $_.parameters.input.value.Keys -contains "ResourceType" } {
+                    # Parameter Files - Determine Resource Type and Name (Any ResourceType except management group)
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.ResourceType' -StringValues ($resourcePath.parameters.input.value.ResourceType) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $currentScope = New-AzOpsScope -Path ($Path.Directory)
+
+                    # Creating Resource Id based on current scope, resource Type and Name of the resource
+                    $this.InitializeMemberVariables("$($currentScope.scope)/providers/$($resourcePath.parameters.input.value.ResourceType)/$($resourcePath.parameters.input.value.Name)")
+                    break
+                }
+                { $_.resources -and
+                    $_.resources[0].type -eq 'Microsoft.Management/managementGroups' } {
+                    # Template - Management Group
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.managementgroups' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $this.InitializeMemberVariables("/providers/Microsoft.Management/managementgroups/{0}" -f ($_.resources[0].name) )
+                    break
+                }
+                { $_.resources -and
+                    $_.resources[0].type -eq 'Microsoft.Management/managementGroups/subscriptions' } {
+                    # Template - Subscription
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile.subscriptions' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $this.InitializeMemberVariables("/subscriptions/{0}" -f ($_.resources[0].name -split '/' | Select-Object -Last 1) )
+                    break
+                }
+                { $_.resources -and
+                    $_.resources[0].type -eq 'Microsoft.Resources/resourceGroups' } {
+                    Write-PSFMessage -Level Verbose -String 'Az OpsScope.InitializeMemberVariablesFromFile.resourceGroups' -StringValues ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    #Get the name of subscription from parent scope
+                    $currentScope = New-AzOpsScope -Path ($Path.Directory.Parent)
+
+                    #Initialize resource group
+                    $this.InitializeMemberVariables("$($currentScope.scope)/resourceGroups/{0}" -f $_.resources[0].name )
+                    break
+                }
+                { $_.resources } {
+                    # Template - 1st resource
+                    Write-PSFMessage -Level Verbose -String 'Az OpsScope.InitializeMemberVariablesFromFile.resource' -StringValues ($_.resources[0].type), ($_.resources[0].name) -FunctionName InitializeMemberVariablesFromFile -ModuleName AzOps
+                    $currentScope = New-AzOpsScope -Path ($Path.Directory)
+                    $this.InitializeMemberVariables("$($currentScope.scope)/providers/$($_.resources[0].type)/$($_.resources[0].name)")
+                    break
+                }
+                Default {
+                    Write-PSFMessage -Level Warning  -String 'AzOpsScope.Input.BadData.TemplateParameterFile' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
+                    Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromDirectory' -StringValues $Path -FunctionName AzOpsScope -ModuleName AzOps
+                    $this.InitializeMemberVariablesFromDirectory($Path.Directory)
+                }
             }
         }
     }

--- a/src/internal/functions/New-AzOpsScope.ps1
+++ b/src/internal/functions/New-AzOpsScope.ps1
@@ -40,7 +40,7 @@
             [AzOpsScope]
     #>
 
-    [OutputType([AzOpsScope])]
+    #[OutputType([AzOpsScope])]
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [Parameter(ParameterSetName = "scope")]
@@ -69,7 +69,8 @@
                     Stop-PSFFunction -String 'New-AzOpsScope.Path.NotFound' -StringValues $Path -EnableException $true -Cmdlet $PSCmdlet
                 }
                 $Path = Resolve-PSFPath -Path $Path -SingleItem -Provider FileSystem
-                if (-not $Path.StartsWith($StatePath)) {
+                $StatePathValidator = Resolve-PSFPath -Path $StatePath -SingleItem -Provider FileSystem
+                if (-not $Path.StartsWith($StatePathValidator)) {
                     Stop-PSFFunction -String 'New-AzOpsScope.Path.InvalidRoot' -StringValues $Path, $StatePath -EnableException $true -Cmdlet $PSCmdlet
                 }
                 Invoke-PSFProtectedCommand -ActionString 'New-AzOpsScope.Creating.FromFile' -Target $Path -ScriptBlock {

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -29,7 +29,7 @@
     'AzOpsScope.Input.BadData.ResourceGroup'                                        = 'Invalid Resource Group Data! Validate integrity of {0}' # ($children.FullName -join ', ')
     'AzOpsScope.Input.BadData.Subscription'                                         = 'Invalid Subscription Data! Validate integrity of {0}' # ($children.FullName -join ', ')
     'AzOpsScope.Input.BadData.UnknownType'                                          = 'Invalid File Structure! Cannot find Management Group / Subscription / Resource Group files in {0}!' # $Path
-    'AzOpsScope.Input.BadData.TemplateParameterFile'                                = 'Unable to determine type from Template of Parameter file: {0}' # filename
+    'AzOpsScope.Input.BadData.TemplateParameterFile'                                = 'Unable to determine type from Template or Template Parameter file: {0}' # filename
     'AzOpsScope.Constructor'                                                        = 'Calling Constructor with value {0}' # scope
     'AzOpsScope.InitializeMemberVariables'                                          = 'Calling InitializeMemberVariablesFromDirectory with value {0}' # scope
     'AzOpsScope.InitializeMemberVariables.Start'                                    = 'Calling InitializeMemberVariables with scope {0}' # Scope


### PR DESCRIPTION
Priority - Normal (BAU).

Removing duplicate code in switch statement due to bug

Scenario:  Empty file with .json is checked in repo/

Behaviour:  Empty fie is not valid JSON file. Empty Json should've minimum file content '{}'. However, due to bug that is combination of Get-Content and ConvertFrom-Json when empty file with .json (that is valid file but not valid Json), switch statement is failing to handle $null value unless assigned explicitly.