### PR TITLE
Added steps to disable rebase merging and merge commits to wiki

### DIFF
--- a/docs/wiki/GitHub-Actions.md
+++ b/docs/wiki/GitHub-Actions.md
@@ -54,8 +54,15 @@ gh secret set 'ARM_CLIENT_ID' -b "<Secret>"
 gh secret set 'ARM_CLIENT_SECRET' -b "<Secret>"
 ```
 
+Disable *Allow Merge commits* and *Allow rebase merging*
+
+```bash
+gh api -X PATCH /repos/{owner}/{repo} -f allow_rebase_merge=false
+gh api -X PATCH /repos/{owner}/{repo} -f allow_merge_commit=false
+```
+
 Initiaite the first Pull workflow
 
 ```bash
-gh api -X POST /repos/:owner/:repo/dispatches -f event_type='Enterprise-Scale Deployment'
+gh api -X POST /repos/{owner}/{repo}/dispatches -f event_type='Enterprise-Scale Deployment'
 ```


### PR DESCRIPTION
Added missing steps to the Scripts section in the GitHub-Actions.md wiki.

- Added steps on how to disable *Allow Merge commits* and *Allow rebase merging* on the repo using GitHub CLI
- Changed the format from `/repos/:owner/:repo` to `/repos/{owner}/{repo}`. Easier to understand and follows the GitHub CLI docs.