### PR TITLE
Process files on git rename status with copy score 

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -166,7 +166,7 @@
                 $deleteSet += $filename
                 continue
             }
-            if ($operation -in 'A', 'M', 'R') { $filename }
+            if ($operation -in 'A', 'M', 'R' -or $operation -match '^R0[0-9][1-9]$') { $filename }
         }
         if ($deleteSet) { $deleteSet = $deleteSet | Sort-Object }
         if ($addModifySet) { $addModifySet = $addModifySet | Sort-Object }

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -166,7 +166,7 @@
                 $deleteSet += $filename
                 continue
             }
-            if ($operation -in 'A', 'M', 'R' -or $operation -match '^R0[0-9][1-9]$') { $filename }
+            if ($operation -in 'A', 'M', 'R' -or $operation -match '^R0[0-9][0-9]$') { $filename }
         }
         if ($deleteSet) { $deleteSet = $deleteSet | Sort-Object }
         if ($addModifySet) { $addModifySet = $addModifySet | Sort-Object }


### PR DESCRIPTION
## Overview/Summary

Process changes in AzOps when git status for files are R of less than 100 value (eg. R099 and below). 
Closing #397 

### Breaking Changes
N/A

## Testing Evidence

![image](https://user-images.githubusercontent.com/16622613/127372828-34806016-f999-4969-825e-1f1ddd7c765e.png)
