### PR TITLE
WhatIf preference for Set-AzContext

### DIFF
--- a/src/internal/functions/Set-AzOpsContext.ps1
+++ b/src/internal/functions/Set-AzOpsContext.ps1
@@ -28,7 +28,7 @@
 
         if ($context.Subscription.Id -ne $ScopeObject.Subscription) {
             Write-PSFMessage -String 'Set-AzOpsContext.Change' -StringValues $context.Subscription.Name, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
-            Set-AzContext -SubscriptionId $scopeObject.Subscription
+            Set-AzContext -SubscriptionId $scopeObject.Subscription -WhatIf:$false
         }
     }
 }


### PR DESCRIPTION
## Overview/Summary

Changed WhatIf preference to $false for Set-AzContext to ensure subscription context can be changed in validate step when Invoke-AzOpsPush is called with the -WhatIf switch.

## This PR fixes/adds/changes/removes
Closing #410 

### Breaking Changes

N/A

## Testing Evidence

![image](https://user-images.githubusercontent.com/16622613/127525633-32fb7663-3018-4c0d-9cd3-3c1777913c3b.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.

