### PR TITLE
Changed generation of policySetDefinitions and improved whatif error handling 

### DIFF
--- a/src/internal/classes/AzOpsScope.ps1
+++ b/src/internal/classes/AzOpsScope.ps1
@@ -225,7 +225,7 @@
             }
             else {
                 if ( (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix') -notcontains 'parameters.json' -and
-                    ("$($this.ResourceProvider)/$($this.Resource)" -eq 'Microsoft.Authorization/policyDefinitions')
+                    ("$($this.ResourceProvider)/$($this.Resource)" -in 'Microsoft.Authorization/policyDefinitions', 'Microsoft.Authorization/policySetDefinitions')
                 ) {
                     $this.StatePath = ($this.GetAzOpsResourcePath() + '.parameters' + (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'))
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Closing #418 and #396

## This PR fixes/adds/changes/removes

1.  Changed so policySetDefinitions generate parameter files instead of regular deployment templates to overcome escaping issues (#418)
2. Improved WhatIf/Validate error handling to throw terminating errors on template errors (#396)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)