### PR TITLE
Fix to enumerate resourceProviders that are not registered in current context

### DIFF
--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -78,7 +78,7 @@
             $null = New-Item -path (Get-PSFConfigValue -FullName 'AzOps.Core.State') -Force -ItemType directory
         }
         $script:AzOpsSubscriptions = Get-AzOpsSubscription -ExcludedOffers $ExcludedSubOffer -ExcludedStates $ExcludedSubState -TenantId $tenantId
-        $script:AzOpsResourceProvider = Get-AzResourceProvider
+        $script:AzOpsResourceProvider = Get-AzResourceProvider -ListAvailable
         $script:AzOpsAzManagementGroup = @()
         $script:AzOpsPartialRoot = @()
         #endregion Initialize & Prepare


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
 
Closing #422. 
## This PR fixes/adds/changes/removes

Added -ListAvailable switch to Get-AzResourceProvider cmdlet to ensure all resourceproviders are enumerated regardless of registration status. 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)