### PR TITLE
Metadata for policyDefinitons/policySetdefinitions and update of dependencies 

### DIFF
--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -52,9 +52,9 @@ PowerShellVersion = '7.0'
 
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(@{ModuleName = 'PSFramework'; RequiredVersion = '1.6.205'; }, 
-               @{ModuleName = 'Az.Accounts'; RequiredVersion = '2.5.1'; }, 
+               @{ModuleName = 'Az.Accounts'; RequiredVersion = '2.5.3'; }, 
                @{ModuleName = 'Az.Billing'; RequiredVersion = '2.0.0'; }, 
-               @{ModuleName = 'Az.Resources'; RequiredVersion = '4.2.0'; })
+               @{ModuleName = 'Az.Resources'; RequiredVersion = '4.3.1'; })
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/src/data/template/Microsoft.Authorization/policyDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policyDefinitions.jq
@@ -1,1 +1,1 @@
-del(.ResourceId, .ResourceName, .PolicyDefinitionId, .SubscriptionId, .Properties.Metadata, .Properties.PolicyType)
+del(.ResourceId, .ResourceName, .PolicyDefinitionId, .SubscriptionId, .Properties.PolicyType, .Properties.Metadata.createdBy, .Properties.Metadata.createdOn, .Properties.Metadata.updatedBy, .Properties.Metadata.updatedOn)

--- a/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
@@ -1,1 +1,1 @@
-del(.ResourceId, .ResourceName, .PolicyDefinitionId, .SubscriptionId, .Properties.Metadata, .Properties.PolicyType)
+del(.ResourceId, .ResourceName, .PolicyDefinitionId, .SubscriptionId, .Properties.PolicyType, .Properties.Metadata.createdBy, .Properties.Metadata.createdOn, .Properties.Metadata.updatedBy, .Properties.Metadata.updatedOn)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Closing #413, #414 and #415

## This PR fixes/adds/changes/removes

1. #414
2. #413
3. Changed jq template for policyDefinitions and policySetDefinitions to include relevant metadata (#415) 

## Testing Evidence

Metadata returned: 
![image](https://user-images.githubusercontent.com/16622613/133241004-9ebedb64-bce4-4c48-87bc-7f096ac828b4.png)
![image](https://user-images.githubusercontent.com/16622613/133241045-5e1e11dd-af8f-4196-ac8a-16990dd5ba5a.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)