### PR TITLE
Remove-AzOpsDeployment - Resource Deletion for role and policy assignment

### DIFF
--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -1,0 +1,162 @@
+function Remove-AzOpsDeployment {
+    <#
+        .SYNOPSIS
+            Delete a Role Assignment / policy Assignment from azure.
+        .DESCRIPTION
+            Delete a Role Assignment / policy Assignment from azure.
+        .PARAMETER TemplateFilePath
+            Path where the ARM templates can be found.
+        .PARAMETER StatePath
+            The root folder under which to find the resource json.
+        .PARAMETER WhatIf
+            If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+        .EXAMPLE
+            > $AzOpsRemovalList | Select-Object $uniqueProperties -Unique | Remove-AzOpsDeployment
+            Remove all unique deployments provided from $AzOpsRemovalList
+    #>
+
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [string]
+        $TemplateFilePath = (Get-PSFConfigValue -FullName 'AzOps.Core.MainTemplate'),
+
+        [string]
+        $StatePath = (Get-PSFConfigValue -FullName 'AzOps.Core.State')
+    )
+
+    process {
+        #Deployment Name
+        $fileItem = Get-Item -Path $TemplateFilePath
+        $deploymentName = $fileItem.BaseName -replace '\.json$' -replace ' ', '_'
+        $deploymentName = "AzOps-RemoveResource-$deploymentName"
+        
+        Write-PSFMessage -String 'Remove-AzOpsDeployment.Processing' -StringValues $deploymentName, $TemplateFilePath -Target $TemplateFilePath
+
+        #region Parse Content
+        $templateContent = Get-Content $TemplateFilePath | ConvertFrom-Json -AsHashtable
+        #endregion
+
+        #region Validate it is AzOpsgenerated template
+        if($templateContent.metadata._generator.name -eq "AzOps")
+        {
+            Write-PSFMessage -Level Verbose -Message 'Remove-AzOpsDeployment.Metadata.Success' -StringValues $TemplateFilePath -Target $TemplateFilePath
+        }
+        else
+        {
+            Write-PSFMessage -Level Error -Message 'Remove-AzOpsDeployment.Metadata.Failed' -StringValues $TemplateFilePath -Target $TemplateFilePath
+            return
+        }
+        #endregion Validate it is AzOpsgenerated template
+
+        #region Resolve Scope
+        try {
+            $scopeObject = New-AzOpsScope -Path $TemplateFilePath -StatePath $StatePath -ErrorAction Stop -WhatIf:$false
+        }
+        catch {
+            Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.Scope.Failed' -Target $TemplateFilePath -StringValues $TemplateFilePath -ErrorRecord $_
+            return
+        }
+        if (-not $scopeObject) {
+            Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.Scope.Empty' -Target $TemplateFilePath -StringValues $TemplateFilePath
+            return
+        }
+        #endregion Resolve Scope
+
+        #region SetContext
+        Set-AzOpsContext -ScopeObject $scopeObject
+        #endregion SetContext
+
+        #GetContext
+        $context = Get-AzContext
+
+        #region PolicyAssignment
+        if($scopeObject.Resource -eq "policyAssignments"){
+
+            #Validate
+            $roleAssignmentPermissionCheck = $false
+            $policyAssignment = Get-AzPolicyAssignment -Id $scopeObject.scope -ErrorAction Continue -ErrorVariable resultsError
+            $roleAssignments = Get-AzRoleAssignment -ServicePrincipalName $context.Account.id -Scope $policyAssignment.Properties.Scope -ErrorAction Continue
+            foreach($role in $roleAssignments){
+                if ( $role.RoleDefinitionName -eq "Owner" -or $role.RoleDefinitionName -eq "User Access Administrator" -or
+                (Get-AzRoleDefinition -Name $role.RoleDefinitionName | Where-Object {$_.Actions -contains "Microsoft.Authorization/policyAssignments/delete" -or $_.Actions -contains "Microsoft.Authorization/policyAssignments/*" -or $_.Actions -contains "Microsoft.Authorization/*"})){
+                    $roleAssignmentPermissionCheck = $true
+                }
+            }
+            if (($resultsError -ne $null) -or (-not $policyAssignment)) {
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemovePolicyAssignment.NoPolicyAssignmentFound' -StringValues $scopeObject.Scope,$resultsError -Target $scopeObject
+                $results = '{0}: What if Operation Failed: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName, $scopeObject.scope
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+                return
+            }
+            elseif ((-not $roleAssignmentPermissionCheck)) {
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $context.Account.Id,$scopeObject.Scope -Target $scopeObject
+                $results = '{0}: What if Operation Failed: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName,$scopeObject.scope
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+                return
+            }
+            else {
+                $results = '{0}: What if succeeded: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName,$scopeObject.scope
+                Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
+                Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+            }
+
+            #removal of resource
+            if ($PSCmdlet.ShouldProcess("RemovePolicyAssignment?")) 
+            {
+                Remove-AzPolicyAssignment -Id $scopeObject.scope -ErrorAction Stop
+            }
+            else{
+                Write-PSFMessage -Level Verbose -String 'Remove-AzOpsDeployment.SkipDueToWhatIf'
+            }
+        }
+        #endregion PolicyAssignment
+
+        #Region roleAssignments
+        if($scopeObject.Resource -eq "roleAssignments")
+        {
+            #Validate
+            $roleAssignmentPermissionCheck = $false
+            $roleAssignment = Get-AzRoleAssignment -ObjectId $templateContent.resources[0].properties.PrincipalId -RoleDefinitionName $templateContent.resources[0].properties.RoleDefinitionName -ErrorAction Continue -ErrorVariable roleAssignmentError | Where-Object {$_.RoleAssignmentId -match $scopeObject.Scope}
+            
+            $roleAssignments = Get-AzRoleAssignment -ServicePrincipalName $context.Account.id -Scope $roleAssignment.Scope -ErrorAction Continue
+            foreach($role in $roleAssignments){
+                if ( $role.RoleDefinitionName -eq "Owner" -or $role.RoleDefinitionName -eq "User Access Administrator" -or
+                (Get-AzRoleDefinition -Name $role.RoleDefinitionName | Where-Object {$_.Actions -contains "Microsoft.Authorization/roleAssignments/delete" -or $_.Actions -contains "Microsoft.Authorization/roleAssignments/*" -or $_.Actions -contains "Microsoft.Authorization/*"}))
+                {
+                    $roleAssignmentPermissionCheck = $true
+                }
+            }
+
+            if (($roleAssignmentError -ne $null) -or (-not $roleAssignment)) {
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveRoleAssignment.NoRoleAssignmentFound' -StringValues $scopeObject.Scope,$resultsError -Target $scopeObject
+                $results = '{0}: What if Failed: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName,$templateContent.resources[0].properties.PrincipalId,$roleAssignment.Scope,$templateContent.resources[0].properties.RoleDefinitionName
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+                return
+            }
+            elseif (-not $roleAssignmentPermissionCheck) {
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $context.Account.Id,$scopeObject.Scope -Target $scopeObject
+                $results = '{0}: What if Failed: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName,$templateContent.resources[0].properties.PrincipalId,$roleAssignment.Scope,$templateContent.resources[0].properties.RoleDefinitionName
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+                return
+            }
+            else {
+                $results = '{0}: What if succeded: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName,$templateContent.resources[0].properties.PrincipalId,$roleAssignment.Scope,$templateContent.resources[0].properties.RoleDefinitionName
+                Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
+                Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
+                Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
+            }
+
+            #Remove of Resource
+            if ($PSCmdlet.ShouldProcess("RemoveRoleAssignment?")) {
+                Remove-AzRoleAssignment -ObjectId $templateContent.resources[0].properties.PrincipalId -RoleDefinitionName $templateContent.resources[0].properties.RoleDefinitionName -Scope $roleAssignment.Scope -ErrorAction Stop
+            }
+            else
+            {
+                Write-PSFMessage -Level Verbose -String 'Remove-AzOpsDeployment.SkipDueToWhatIf'
+            }
+        }
+        #endregion Roleassignments
+    }
+}

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -223,6 +223,16 @@
     'Register-AzOpsResourceProvider.Processing'                                     = 'Processing resource provider {0} from {1}' # $ScopeObject, $FileName
     'Register-AzOpsResourceProvider.Provider.Register'                              = 'Registering provider {0}' # $resourceprovider.ProviderNamespace
 
+    'Remove-AzOpsDeployment.Processing'                                             = 'Processing deployment {0} for template {1}' # $DeploymentName, $TemplateFilePath
+    'Remove-AzOpsDeployment.Metadata.Failed'                                        = 'This is user defined template {0} . Resource Deletion is only defined for Azops Generated template' #$TemplateFilePath
+    'Remove-AzOpsDeployment.Metadata.Success'                                       = 'Processing AzOps Generated Template File {0}' # $TemplateFilePath
+    'Remove-AzOpsDeployment.Scope.Failed'                                           = 'Failed to resolve the scope for template {0}' # $TemplateFilePath
+    'Remove-AzOpsDeployment.Scope.Empty'                                            = 'Unable to determine the scope of template {0}' # $TemplateFilePath
+    'Remove-AzOpsDeployment.SkipDueToWhatIf'                                        = 'Skipping deployment due to WhatIf' #
+    'Remove-AzOpsDeployment.RemoveRoleAssignment.NoRoleAssignmentFound'             = 'Unable to find Role assignment with id {0} resulted in error {1}'# $roleAssignmentId,$resultsError
+    'Remove-AzOpsDeployment.RemovePolicyAssignment.NoPolicyAssignmentFound'         = 'Unable to find Policy assignment with id {0} resulted in error {1}'# $policyAssignmentId,$resultsError
+    'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext'            = 'This Context {0} dont have permission to remove on scope {1}'# $context.Account.id, $Id
+
     'Save-AzOpsManagementGroupChildren.Creating.Scope'                              = 'Creating scope object' #
     'Save-AzOpsManagementGroupChildren.Data.Directory'                              = 'Resolved state path directory: {0}' # $statepathDirectory
     'Save-AzOpsManagementGroupChildren.Data.FileName'                               = 'Resolved state path filename: {0}' # $statepathFileName
@@ -238,4 +248,5 @@
 
     'Set-AzOpsContext.Change'                                                       = 'Changing active subscription from {0} to {1} ({2})' # $context.Subscription.Name, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
     'Set-AzOpsWhatIfOutput.WhatIfFile'                                              = 'Creating WhatIf markdown and json files' # 
+    'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}'
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The resource deletion function is an enhancement which takes care of deleting the role and policy assignments from Azure based on the AzOps pull generated templates.

fixes #395 
closes #395 

## This PR fixes/adds/changes/removes

1. Adds Remove-AzOps Deployment as a new function
2. Updates Set-AzOpsWhatIfOutput on existing function logic
3. Updates Invoke-AzOpsPush.ps1 on existing function logic
4. Updates Strings.psd1 for messages


### Breaking Changes

1. N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).
![image](https://user-images.githubusercontent.com/37686584/134545445-5909a415-daed-46f6-a3c7-ae2f0acdff3b.png)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
