### PR TITLE
Bugfix for AzOpsRoleDefinition when assignment scope contain trailing…

### DIFF
--- a/src/internal/classes/AzOpsRoleDefinition.ps1
+++ b/src/internal/classes/AzOpsRoleDefinition.ps1
@@ -3,9 +3,10 @@
     [string]$Name
     [string]$Id
     [hashtable]$Properties
-    
     AzOpsRoleDefinition($Properties) {
-        $this.Id = $Properties.AssignableScopes[0] + '/providers/Microsoft.Authorization/roleDefinitions/' + $Properties.Id
+        # Removing the Trailing slash to ensure that '/' is not appended twice when adding '/providers/xxx'.
+        # Example: '/subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/' is a valid assignment scope.
+        $this.Id = '/' + $Properties.AssignableScopes[0].Trim('/') + '/providers/Microsoft.Authorization/roleDefinitions/' + $Properties.Id
         $this.Name = $Properties.Id
         $this.Properties = [ordered]@{
             AssignableScopes = @($Properties.AssignableScopes)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Bugfix for AzOpsRoleDefinition when assignment scope contain trailing '/'

## This PR fixes/adds/changes/removes
None

### Breaking Changes

None
## Testing Evidence
```
[DBG]: PS C:\Git\uday31in\AzOps> $roleDefinitions[0].Properties
Name                           Value
----                           -----
RoleName                       Platform Owners
Permissions                    {System.Collections.Specialized.OrderedDictionary}
Description                    Custom Role that grants full access to manage all Platform resources, including the ability to assign roles in Azure RBAC
AssignableScopes               {/subscriptions/dddbadc2-9d31-43f4-a7e3-ae83c9da646a/}


Scope                      : /subscriptions/dddbadc2-9d31-43f4-a7e3-ae83c9da646a/providers/Microsoft.Authorization/roleDefinitions/d7caacc3-956c-527e-afe2-ee0a91a560e1
Type                       : resource
Name                       : d7caacc3-956c-527e-afe2-ee0a91a560e1
StatePath                  : C:\Git\uday31in\AzOps\root\tenant root group (360d509d-82f2-42d5-9446-fbf417d9139c)\msdn-udpandya (dddbadc2-9d31-43f4-a7e3-ae83c9da646a)\.\microsoft.authorization_roledefinitions-d7caacc3-956c-527e-afe2-ee0a91a560e1.json
ManagementGroup            : 360d509d-82f2-42d5-9446-fbf417d9139c
ManagementGroupDisplayName : Tenant Root Group
Subscription               : dddbadc2-9d31-43f4-a7e3-ae83c9da646a
SubscriptionDisplayName    : msdn-udpandya
ResourceGroup              :
ResourceProvider           : Microsoft.Authorization
Resource                   : roleDefinitions

#Extra slash Breaks the New-AzOpsScope function

Scope                      : /subscriptions/dddbadc2-9d31-43f4-a7e3-ae83c9da646a//providers/Microsoft.Authorization/roleDefinitions/d7caacc3-956c-527e-afe2-ee0a91a560e1
Type                       :
Name                       :
StatePath                  :
ManagementGroup            :
ManagementGroupDisplayName :
Subscription               :
SubscriptionDisplayName    :
ResourceGroup              :
ResourceProvider           : 
Resource                   :


```
## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
- [X] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)