### PR TITLE
Fix/square bracket

### DIFF
--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -1,1 +1,22 @@
-_Coming soon_
+# AzOps FAQ
+
+This article answers frequently asked questions relating to AzOps.
+
+## In this Section
+
+  - [Subscription or resources not showing up in repository?](#subscription-or-resources-not-showing-up-in-repository)
+
+
+
+## Subscription or resources not showing up in your repository?
+
+If subscriptions, resource groups or resources are not showing up in your repository (it affects both pull operations and push deployments of new resources). This can happen because there are invalid characters in the resource path. 
+
+To confirm if this applies to you, check the pipeline logs for any of the following messages:
+```powershell
+[ConvertTo-AzOpsState] The specified AzOpsState file contains invalid characters (remove any "[" or "]" characters)! <PathToResource> 
+```
+
+```powershell
+[New-AzOpsScope] Path not found: <PathToResource> 
+```

--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -4,13 +4,13 @@ This article answers frequently asked questions relating to AzOps.
 
 ## In this Section
 
-  - [Subscription or resources not showing up in repository?](#subscription-or-resources-not-showing-up-in-repository)
+  - [Subscriptions or resources not showing up in repository?](#subscriptions-or-resources-not-showing-up-in-repository)
 
 
 
-## Subscription or resources not showing up in your repository?
+## Subscriptions or resources not showing up in your repository?
 
-If subscriptions, resource groups or resources are not showing up in your repository (it affects both pull operations and push deployments of new resources). This can happen because there are invalid characters in the resource path. 
+If there are invalid characters in the resource path, discovery of subscriptions, resource groups or resources will fail during push or pull operations.
 
 To confirm if this applies to you, check the pipeline logs for any of the following messages:
 ```powershell

--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -20,3 +20,4 @@ To confirm if this applies to you, check the pipeline logs for any of the follow
 ```powershell
 [New-AzOpsScope] Path not found: <PathToResource> 
 ```
+Remove the invalid resource or character and retry the operation.

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -65,12 +65,6 @@
                 Scope                     = $ScopeObject.Scope
             }
 
-        #    #check for invalid characters "[" "]"
-        #    if ($FilePath -match [regex]::Escape("[") -or $FilePath -match [regex]::Escape("]")) {
-        #        Write-PSFMessage -Level Error -String 'Invoke-AzOpsPush.Resolve.InvalidCharacter' -StringValues $FilePath -Tag pwsh -FunctionName 'Invoke-AzOpsPush' -Target $ScopeObject
-        #        return
-        #    }
-
             $fileItem = Get-Item -Path $FilePath
             if ($fileItem.Extension -notin '.json' , '.bicep') {
                 Write-PSFMessage -Level Warning -String 'Invoke-AzOpsPush.Resolve.NoJson' -StringValues $fileItem.FullName -Tag pwsh -FunctionName 'Invoke-AzOpsPush' -Target $ScopeObject

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -65,11 +65,18 @@
                 Scope                     = $ScopeObject.Scope
             }
 
+        #    #check for invalid characters "[" "]"
+        #    if ($FilePath -match [regex]::Escape("[") -or $FilePath -match [regex]::Escape("]")) {
+        #        Write-PSFMessage -Level Error -String 'Invoke-AzOpsPush.Resolve.InvalidCharacter' -StringValues $FilePath -Tag pwsh -FunctionName 'Invoke-AzOpsPush' -Target $ScopeObject
+        #        return
+        #    }
+
             $fileItem = Get-Item -Path $FilePath
             if ($fileItem.Extension -notin '.json' , '.bicep') {
                 Write-PSFMessage -Level Warning -String 'Invoke-AzOpsPush.Resolve.NoJson' -StringValues $fileItem.FullName -Tag pwsh -FunctionName 'Invoke-AzOpsPush' -Target $ScopeObject
                 return
             }
+
             #endregion Initialization Prep
 
             #region Case: Parameters File

--- a/src/internal/functions/ConvertTo-AzOpsState.ps1
+++ b/src/internal/functions/ConvertTo-AzOpsState.ps1
@@ -87,6 +87,10 @@
         else {
             $objectFilePath = $ExportPath
         }
+        # Check for invalid characters "[" or "]"
+        if ($objectFilePath -match [regex]::Escape("[") -or $objectFilePath -match [regex]::Escape("]")) {
+            Stop-PSFFunction -String 'ConvertTo-AzOpsState.File.InvalidCharacter' -StringValues $objectFilePath -EnableException $true -Cmdlet $PSCmdlet
+        }
         # Create folder structure if it doesn't exist
         if (-not (Test-Path -Path $objectFilePath)) {
             Write-PSFMessage -String 'ConvertTo-AzOpsState.File.Create' -StringValues $objectFilePath

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -161,10 +161,11 @@
     'Invoke-AzOpsPush.Deploy.ResourceProvider'                                    = 'Invoking new state deployment - *.resourceproviders.json for a file {0}' # $addition
     'Invoke-AzOpsPush.Deploy.Subscription'                                        = 'Invoking new state deployment - *.subscription.json for a file {0}' # $addition
     'Invoke-AzOpsPush.Deployment.Required'                                        = 'Deployment required' #
+    'Invoke-AzOpsPush.Resolve.ConvertBicepTemplate'                               = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FoundTemplate'                                      = 'Found template {1} for parameters {0}' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FoundBicepTemplate'                                 = 'Found Bicep template {1} for parameters {0}' # $FilePath, $templatePath
-    'Invoke-AzOpsPush.Resolve.ConvertBicepTemplate'                               = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FromMainTemplate'                                   = 'Determining template from main template file: {0}' # $mainTemplateItem.FullName
+    'Invoke-AzOpsPush.Resolve.InvalidCharacter'                                   = 'The specified file contains invalid characters (remove any "[" or "]" characters)! Skipping {0}' # $FilePath
     'Invoke-AzOpsPush.Resolve.MainTemplate.NotSupported'                          = 'effectiveResourceType: {0} AzOpsMainTemplate does NOT supports resource type {0} in {1}. Deployment will be ignored' # $effectiveResourceType, $AzOpsMainTemplate.FullName
     'Invoke-AzOpsPush.Resolve.MainTemplate.Supported'                             = 'effectiveResourceType: {0} - AzOpsMainTemplate supports resource type {0} in {1}' # $effectiveResourceType, $AzOpsMainTemplate.FullName
     'Invoke-AzOpsPush.Resolve.NoJson'                                             = 'The specified file is not a json file at all! Skipping {0}' # $fileItem.FullName

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -56,6 +56,7 @@
     'ConvertTo-AzOpsState.Exporting'                                                = 'Exporting AzOpsState to {0}' # $resourceData.ObjectFilePath
     'ConvertTo-AzOpsState.Exporting.Default'                                        = 'Exporting input resource to AzOpsState to {0}' # $resourceData.ObjectFilePath
     'ConvertTo-AzOpsState.File.Create'                                              = 'AzOpsState file not found. Creating new: {0}' # $ObjectFilePath
+    'ConvertTo-AzOpsState.File.InvalidCharacter'                                    = 'The specified AzOpsState file contains invalid characters (remove any "[" or "]" characters)! Skipping {0}' # $ObjectFilePath
     'ConvertTo-AzOpsState.File.UseExisting'                                         = 'AzOpsState file is found. Using existing file: {0}' # $ObjectFilePath
     'ConvertTo-AzOpsState.NoExportPath'                                             = 'No export path found for {0}. Ensure the original data type remains intact or specify an -ExportPath' # $Resource
     'ConvertTo-AzOpsState.Processing'                                               = 'Processing input: {0}' # $Resource
@@ -165,7 +166,6 @@
     'Invoke-AzOpsPush.Resolve.FoundTemplate'                                      = 'Found template {1} for parameters {0}' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FoundBicepTemplate'                                 = 'Found Bicep template {1} for parameters {0}' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FromMainTemplate'                                   = 'Determining template from main template file: {0}' # $mainTemplateItem.FullName
-    'Invoke-AzOpsPush.Resolve.InvalidCharacter'                                   = 'The specified file contains invalid characters (remove any "[" or "]" characters)! Skipping {0}' # $FilePath
     'Invoke-AzOpsPush.Resolve.MainTemplate.NotSupported'                          = 'effectiveResourceType: {0} AzOpsMainTemplate does NOT supports resource type {0} in {1}. Deployment will be ignored' # $effectiveResourceType, $AzOpsMainTemplate.FullName
     'Invoke-AzOpsPush.Resolve.MainTemplate.Supported'                             = 'effectiveResourceType: {0} - AzOpsMainTemplate supports resource type {0} in {1}' # $effectiveResourceType, $AzOpsMainTemplate.FullName
     'Invoke-AzOpsPush.Resolve.NoJson'                                             = 'The specified file is not a json file at all! Skipping {0}' # $fileItem.FullName


### PR DESCRIPTION
## Overview/Summary

Added logic to handle resources with square brackets ('[' and ']') by improved error messages and added FAQ information that these characters are invalid and thus not supported by AzOps.

closing #443 and #351 

## This PR fixes/adds/changes/removes

1. Added FAQ section for invalid characters
2. Added logic to provide error message when detecting invalid character

### Breaking Changes

N/A

## Testing Evidence

Validated in Push and Pull workflows.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.