### PR TITLE
SkipResourceType

### DIFF
--- a/docs/wiki/Settings.md
+++ b/docs/wiki/Settings.md
@@ -17,8 +17,9 @@ The following configuration values can be modified within the `settings.json` fi
 | 16 | SkipPolicy                           | Generate template files for Policy types                     |
 | 17 | SkipResource                         | Generate template files for Resources within Resource Groups |
 | 18 | SkipResourceGroup                    | Generate folder hierachy for all Resource Groups             |
-| 19 | SkipRole                             | Generate template files for Role types                       |
-| 20 | State                                | Default top level folder name within the repository          |
-| 21 | SubscriptionsToIncludeResourceGroups | Generate folder hierachy for specific Resource Groups        |
+| 19 | SkipResourceType                     | Skip these Resource Types                                    |
+| 20 | SkipRole                             | Generate template files for Role types                       |
+| 21 | State                                | Default top level folder name within the repository          |
+| 22 | SubscriptionsToIncludeResourceGroups | Generate folder hierachy for specific Resource Groups        |
 | 23 | TemplateParameterFileSuffix          | Default template file suffix                                 |
 | 24 | ThrottleLimit                        |                                                              |

--- a/docs/wiki/Settings.md
+++ b/docs/wiki/Settings.md
@@ -17,7 +17,7 @@ The following configuration values can be modified within the `settings.json` fi
 | 16 | SkipPolicy                           | Generate template files for Policy types                     |
 | 17 | SkipResource                         | Generate template files for Resources within Resource Groups |
 | 18 | SkipResourceGroup                    | Generate folder hierachy for all Resource Groups             |
-| 19 | SkipResourceType                     | Skip these Resource Types                                    |
+| 19 | SkipResourceType                     | Skip specific [Resource Types](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types)  (only targets resourcegroup scoped resources)|
 | 20 | SkipRole                             | Generate template files for Role types                       |
 | 21 | State                                | Default top level folder name within the repository          |
 | 22 | SubscriptionsToIncludeResourceGroups | Generate folder hierachy for specific Resource Groups        |

--- a/docs/wiki/Settings.md
+++ b/docs/wiki/Settings.md
@@ -17,7 +17,7 @@ The following configuration values can be modified within the `settings.json` fi
 | 16 | SkipPolicy                           | Generate template files for Policy types                     |
 | 17 | SkipResource                         | Generate template files for Resources within Resource Groups |
 | 18 | SkipResourceGroup                    | Generate folder hierachy for all Resource Groups             |
-| 19 | SkipResourceType                     | Skip specific [Resource Types](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types)  (only targets resourcegroup scoped resources)|
+| 19 | SkipResourceType                     | Skip specific [Resource Types](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types)  (only targets Resource Group scoped resources)|
 | 20 | SkipRole                             | Generate template files for Role types                       |
 | 21 | State                                | Default top level folder name within the repository          |
 | 22 | SubscriptionsToIncludeResourceGroups | Generate folder hierachy for specific Resource Groups        |

--- a/src/internal/configurations/Core.ps1
+++ b/src/internal/configurations/Core.ps1
@@ -15,6 +15,7 @@ Set-PSFConfig -Module AzOps -Name Core.PartialMgDiscoveryRoot -Value @() -Initia
 Set-PSFConfig -Module AzOps -Name Core.SkipPolicy -Value $false -Initialize -Validation bool -Description '-'
 Set-PSFConfig -Module AzOps -Name Core.SkipResource -Value $true -Initialize -Validation bool -Description 'Global flag to indicate whether resource should be discovered or not. Requires SkipResourceGroup to be false.'
 Set-PSFConfig -Module AzOps -Name Core.SkipResourceGroup -Value $false -Initialize -Validation bool -Description 'Global flag to indicate whether resource group should be discovered or not'
+Set-PSFConfig -Module AzOps -Name Core.SkipResourceType -Value @('Microsoft.VSOnline/plans','Microsoft.PowerPlatform/accounts','Microsoft.PowerPlatform/enterprisePolicies') -Initialize -Validation stringarray -Description 'Global flag to skip discovery of specific Resource types.'
 Set-PSFConfig -Module AzOps -Name Core.SkipRole -Value $false -Initialize -Validation bool -Description '-'
 Set-PSFConfig -Module AzOps -Name Core.State -Value (Join-Path $pwd -ChildPath "root") -Initialize -Validation string -Description 'Folder to store AzOpsState artefact'
 Set-PSFConfig -Module AzOps -Name Core.SubscriptionsToIncludeResourceGroups -Value @('*') -Initialize -Validation stringarray -Description 'Requires SkipResourceGroup to be false. Subscription ID or Display Name that matches the filter. Powershell filter that matches with like operator is supported.'


### PR DESCRIPTION
## Overview/Summary

Adds the capability to exclude/skip resource types at rg scope that should not or cant be synced.
By default it excludes/skips: 'Microsoft.VSOnline/plans','Microsoft.PowerPlatform/accounts','Microsoft.PowerPlatform/enterprisePolicies'

## This PR fixes/adds/changes/removes

1. closing #427
2. adds new setting called "SkipResourceType"

### Breaking Changes

N/A

## Testing Evidence

Tested that declared resource types are excluded from workflows.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.