### PR TITLE
WhatIfOutput

### DIFF
--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -37,13 +37,13 @@
         }
         else {
             $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)
-            $resultstring = $Results | Out-String
-            $resultstringmeasure = $resultstring | Measure-Object -Line -Character -Word
-            if ($($resultstringmeasure.Characters) -gt $ResultSizeLimit) {
+            $resultString = $Results | Out-String
+            $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
+            if ($($resultStringMeasure.Characters) -gt $ResultSizeLimit) {
                 $mdOutput = 'WhatIf Results: WhatIf is too large for comment field, for more details look at PR files to determine changes.'
             }
             else {
-                $mdOutput = 'WhatIf Results: Resource Creation:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultstring
+                $mdOutput = 'WhatIf Results: Resource Creation:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString
             }
             Add-Content -Path '/tmp/OUTPUT.json' -Value $resultJson -WhatIf:$false
         }

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -28,8 +28,8 @@
         Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile'
 
         if (-not (Test-Path -Path '/tmp/OUTPUT.md')) {
-            New-Item -Path '/tmp/OUTPUT.md'
-            New-Item -Path '/tmp/OUTPUT.json'
+            New-Item -Path '/tmp/OUTPUT.md' -WhatIf:$false
+            New-Item -Path '/tmp/OUTPUT.json' -WhatIf:$false
         }
 
         if ($RemoveAzOpsFlag) {


### PR DESCRIPTION
## Overview/Summary

Updated WhatIfOutput information attached to comments during PR Validate Action. Makes information provided easier to read. related #417 

## This PR fixes/adds/changes/removes

1. Changed Set-AzOpsWhatIfOutput.ps1 output from full json to standard WhatIf output.
2. Added parameter for result size and set default value to 64.000 (Github limit 65.000)

### Breaking Changes

N/A

## Testing Evidence

Testing performed:
![image](https://user-images.githubusercontent.com/64077181/141205355-fa77ff11-5ec3-4dbc-88ca-166fbb1cb19a.png)
![image](https://user-images.githubusercontent.com/64077181/141205501-4c9ec489-2592-4f2a-aeeb-5a6974b7c4bd.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.