### PR TITLE
Update Azure-Pipelines.md

### DIFF
--- a/docs/wiki/Azure-Pipelines.md
+++ b/docs/wiki/Azure-Pipelines.md
@@ -174,7 +174,7 @@ If you don't see the subscription you're looking for, select global subscription
     13|SubscriptionsToIncludeResourceGroups|If `*` is mentioned then, it will generate folder hierachy for all Resource Groups, else specific resource group can be mentioned |`"Core.SubscriptionsToIncludeResourceGroups": "*"`
     14|TemplateParameterFileSuffix|Its generated the template file with specific file suffix|`"Core.TemplateParameterFileSuffix": ".json"`
 
-- Now, We are good to trigger pull to fech the existing Azure environment.
+- Now, we are good to trigger the first push, which will in turn trigger the first pull to fetch the existing Azure environment.
 ![Pipelines](./Media/Pipelines/Pipelines.PNG)  
 
 - Once, pull pipeline complete it will look like below screenshot.


### PR DESCRIPTION
## Overview/Summary

update az pipeline docs to propose push before pull. pull pipeline will otherwise fail as it is configured with the push pipeline as its resource.

## This PR fixes/adds/changes/removes

If we try to pull having never run a successful push az devops returns the cryptic
The pipeline is not valid error: Unable to resolve latest version

Similar to this https://blogs.blackmarble.co.uk/rfennell/2020/08/27/fix-for-the-pipeline-is-not-valid-error-unable-to-resolve-latest-version-on-an-azure-devops-yaml-pipeline/

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)