### PR TITLE
Update Get-Item

### DIFF
--- a/src/internal/classes/AzOpsScope.ps1
+++ b/src/internal/classes/AzOpsScope.ps1
@@ -56,7 +56,7 @@
         Write-PSFMessage -Level Verbose -String 'AzOpsScope.Constructor' -StringValues $scope -FunctionName AzOpsScope -ModuleName AzOps
         $this.StateRoot = $StateRoot
         if (Test-Path -Path $scope) {
-            if ((Get-Item $scope).GetType().ToString() -eq 'System.IO.FileInfo') {
+            if ((Get-Item $scope -Force).GetType().ToString() -eq 'System.IO.FileInfo') {
                 #Strong confidence based on content - file
                 Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromFile' -StringValues $scope -FunctionName AzOpsScope -ModuleName AzOps
                 $this.InitializeMemberVariablesFromFile($Scope)
@@ -81,7 +81,7 @@
         $subscriptionFileName = "microsoft.subscription_subscriptions-*$(Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')"
         $resourceGroupFileName = "microsoft.resources_resourceGroups-*$(Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')"
 
-        if ($Path.FullName -eq (Get-Item $this.StateRoot).FullName) {
+        if ($Path.FullName -eq (Get-Item $this.StateRoot -Force).FullName) {
             # Root tenant path
             Write-PSFMessage -Level Verbose -String 'AzOpsScope.InitializeMemberVariablesFromDirectory.RootTenant' -StringValues $Path -FunctionName InitializeMemberVariablesFromDirectory -ModuleName AzOps
             $this.InitializeMemberVariables("/")

--- a/src/internal/functions/New-AzOpsScope.ps1
+++ b/src/internal/functions/New-AzOpsScope.ps1
@@ -74,7 +74,7 @@
                     Stop-PSFFunction -String 'New-AzOpsScope.Path.InvalidRoot' -StringValues $Path, $StatePath -EnableException $true -Cmdlet $PSCmdlet
                 }
                 Invoke-PSFProtectedCommand -ActionString 'New-AzOpsScope.Creating.FromFile' -Target $Path -ScriptBlock {
-                    [AzOpsScope]::new($(Get-Item -Path $Path), $StatePath)
+                    [AzOpsScope]::new($(Get-Item -Path $Path -Force), $StatePath)
                 } -EnableException $true -PSCmdlet $PSCmdlet
             }
         }


### PR DESCRIPTION
## Overview/Summary

Fixes issue with custom path folder '/.az' not working as expected during scope creation. Get-Item does not detect the path unless used in combination with -Force.

[https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-item?view=powershell-7.2](url)

## This PR fixes/adds/changes/removes

1. Adds "-Force" to Get-Item commands in AzOpsScope.ps1 and New-AzOpsScope.ps1

### Breaking Changes

N/A

## Testing Evidence

Test have been performed with pull/validate/push on management group scope with policy assignment and definition.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.