### PR TITLE
Expanded Pester automated integration testing

### DIFF
--- a/scripts/Dependencies.ps1
+++ b/scripts/Dependencies.ps1
@@ -4,7 +4,7 @@ param (
 )
 
 # Development Modules
-$modules = @("Az.Network","Pester", "PSModuleDevelopment", "PSScriptAnalyzer")
+$modules = @("Pester", "PSModuleDevelopment", "PSScriptAnalyzer")
 Write-Host "Installing development modules"
 foreach ($module in $modules) {
     Install-Module $module -Repository $Repository -Force

--- a/scripts/Dependencies.ps1
+++ b/scripts/Dependencies.ps1
@@ -4,7 +4,7 @@ param (
 )
 
 # Development Modules
-$modules = @("Pester", "PSModuleDevelopment", "PSScriptAnalyzer")
+$modules = @("Az.Network","Pester", "PSModuleDevelopment", "PSScriptAnalyzer")
 Write-Host "Installing development modules"
 foreach ($module in $modules) {
     Install-Module $module -Repository $Repository -Force

--- a/scripts/Dependencies.ps1
+++ b/scripts/Dependencies.ps1
@@ -16,7 +16,7 @@ Write-Host "Installing runtime modules"
 foreach ($dependency in $data.RequiredModules) {
     $module = Get-Module -Name $dependency -ListAvailable
     if ($null -ne $module) { Uninstall-Module -Name $dependency -Force }
-    Install-Module -Name $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -Repository $Repository -Force
+    Install-Module -Name $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -Repository $Repository
 }
 # Download and add bicep to PATH
 curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64

--- a/scripts/Dependencies.ps1
+++ b/scripts/Dependencies.ps1
@@ -4,6 +4,7 @@ param (
 )
 
 # Development Modules
+Set-PSRepository -Name $Repository -InstallationPolicy Trusted
 $modules = @("Pester", "PSModuleDevelopment", "PSScriptAnalyzer")
 Write-Host "Installing development modules"
 foreach ($module in $modules) {

--- a/src/tests/Pester.ps1
+++ b/src/tests/Pester.ps1
@@ -13,6 +13,8 @@
     $Exclude = @("Help.Tests.ps1", "PSScriptAnalyzer.Tests.ps1")
 )
 
+Set-PSFConfig -FullName PSFramework.Message.Info.Maximum -Value 9
+
 Write-PSFMessage -Level Important -Message "Starting Tests"
 
 Write-PSFMessage -Level Important -Message "Importing Module"

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -145,7 +145,7 @@ Describe "Repository" {
         # the filesystem are aligned.
         #
 
-        $script:policyAssignments = (Get-AzPolicyAssignment | Where-Object Name -eq "TestPolicyAssignment")
+        $script:policyAssignments = Get-AzPolicyAssignment -Name "TestPolicyAssignment" -Scope "/providers/Microsoft.Management/managementGroups/$($script:managementManagementGroup.Name)"
         $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)
         $script:resourceGroup = (Get-AzResourceGroup | Where-Object ResourceGroupName -eq "Application")
         $script:roleAssignments = (Get-AzRoleAssignment -ObjectId "1b993954-3377-46fd-a368-58fff7420021" | Where-Object {$_.Scope -eq "/subscriptions/$script:subscriptionId" -and $_.RoleDefinitionId -eq "acdd72a7-3385-48ef-bd42-f606fba81ae7"})
@@ -182,47 +182,47 @@ Describe "Repository" {
 
         $filePaths = (Get-ChildItem -Path $generatedRootPath -Recurse)
 
-        $script:tenantRootGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$($script:tenantId).json")
+        $script:tenantRootGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$(($script:tenantId).toLower()).json")
         $script:tenantRootGroupDirectory = ($script:tenantRootGroupPath).Directory
         $script:tenantRootGroupFile = ($script:tenantRootGroupPath).FullName
         Write-PSFMessage -Level Debug -Message "TenantRootGroupPath: $($script:tenantRootGroupFile)" -FunctionName "BeforeAll"
 
-        $script:testManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$($script:testManagementGroup.Name).json")
+        $script:testManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$(($script:testManagementGroup.Name).toLower()).json")
         $script:testManagementGroupDirectory = ($script:testManagementGroupPath).Directory
         $script:testManagementGroupFile = ($script:testManagementGroupPath).FullName
         Write-PSFMessage -Level Debug -Message "TestManagementGroupFile: $($script:testManagementGroupFile)" -FunctionName "BeforeAll"
 
-        $script:platformManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$($script:platformManagementGroup.Name).json")
+        $script:platformManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$(($script:platformManagementGroup.Name).toLower()).json")
         $script:platformManagementGroupDirectory = ($script:platformManagementGroupPath).Directory
         $script:platformManagementGroupFile = ($script:platformManagementGroupPath).FullName
         Write-PSFMessage -Level Debug -Message "PlatformManagementGroupFile: $($script:platformManagementGroupFile)" -FunctionName "BeforeAll"
 
-        $script:managementManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$($script:managementManagementGroup.Name).json")
+        $script:managementManagementGroupPath = ($filePaths | Where-Object Name -eq "microsoft.management_managementgroups-$(($script:managementManagementGroup.Name).toLower()).json")
         $script:managementManagementGroupDirectory = ($script:managementManagementGroupPath).Directory
         $script:managementManagementGroupFile = ($script:managementManagementGroupPath).FullName
         Write-PSFMessage -Level Debug -Message "ManagementManagementGroupFile: $($script:managementManagementGroupFile)" -FunctionName "BeforeAll"
 
-        $script:policyAssignmentsPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_policyassignments-$($script:policyAssignments.Name).json")
+        $script:policyAssignmentsPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_policyassignments-$(($script:policyAssignments.Name).toLower()).json")
         $script:policyAssignmentsDirectory = ($script:policyAssignmentsPath).Directory
         $script:policyAssignmentsFile = ($script:policyAssignmentsPath).FullName
         Write-PSFMessage -Level Debug -Message "PolicyAssignmentsFile: $($script:policyAssignmentsFile)" -FunctionName "BeforeAll"
 
-        $script:subscriptionPath = ($filePaths | Where-Object Name -eq "microsoft.subscription_subscriptions-$($script:subscription.Id).json")
+        $script:subscriptionPath = ($filePaths | Where-Object Name -eq "microsoft.subscription_subscriptions-$(($script:subscription.Id).toLower()).json")
         $script:subscriptionDirectory = ($script:subscriptionPath).Directory
         $script:subscriptionFile = ($script:subscriptionPath).FullName
         Write-PSFMessage -Level Debug -Message "SubscriptionFile: $($script:subscriptionFile)" -FunctionName "BeforeAll"
 
-        $script:resourceGroupPath = ($filePaths | Where-Object Name -eq "microsoft.resources_resourcegroups-$($script:resourceGroup.ResourceGroupName).json")
+        $script:resourceGroupPath = ($filePaths | Where-Object Name -eq "microsoft.resources_resourcegroups-$(($script:resourceGroup.ResourceGroupName).toLower()).json")
         $script:resourceGroupDirectory = ($script:resourceGroupPath).Directory
         $script:resourceGroupFile = ($script:resourceGroupPath).FullName
         Write-PSFMessage -Level Debug -Message "ResourceGroupFile: $($script:resourceGroupFile)" -FunctionName "BeforeAll"
 
-        $script:roleAssignmentsPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_roleassignments-$($script:roleAssignments.RoleAssignmentId -replace ".*/").json")
+        $script:roleAssignmentsPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_roleassignments-$(($script:roleAssignments.RoleAssignmentId).toLower() -replace ".*/").json")
         $script:roleAssignmentsDirectory = ($script:roleAssignmentsPath).Directory
         $script:roleAssignmentsFile = ($script:roleAssignmentsPath).FullName
         Write-PSFMessage -Level Debug -Message "RoleAssignmentFile: $($script:roleAssignmentsFile)" -FunctionName "BeforeAll"
 
-        $script:routeTablePath = ($filePaths | Where-Object Name -eq "microsoft.network_routetables-$($script:routeTable.Name).json")
+        $script:routeTablePath = ($filePaths | Where-Object Name -eq "microsoft.network_routetables-$(($script:routeTable.Name).toLower()).json")
         $script:routeTableDirectory = ($script:routeTablePath).Directory
         $script:routeTableFile = ($script:routeTablePath).FullName
         Write-PSFMessage -Level Debug -Message "RouteTableFile: $($script:routeTableFile)" -FunctionName "BeforeAll"

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -132,10 +132,11 @@ Describe "Repository" {
         # can be tested against to ensure structure
         # is correct and data model hasn't changed.
         #
-
+        
+        Set-PSFConfig -FullName AzOps.Core.SubscriptionsToIncludeResourceGroups -Value $script:subscriptionId
         Write-PSFMessage -Level Verbose -Message "Generating folder structure" -FunctionName "BeforeAll"
         try {
-            Invoke-AzOpsPull -PartialMgDiscoveryRoot $($script:managementGroupDeployment.Outputs.testManagementGroup.value) -SkipRole:$false -SkipPolicy:$false -SkipResource:$false
+            Invoke-AzOpsPull -SkipRole:$false -SkipPolicy:$false -SkipResource:$false
         }
         catch {
             Write-PSFMessage -Level Critical -Message "Initialize failed" -Exception $_.Exception

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -149,8 +149,8 @@ Describe "Repository" {
         $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)
         $script:resourceGroup = (Get-AzResourceGroup | Where-Object ResourceGroupName -eq "Application")
         $script:roleAssignments = (Get-AzRoleAssignment -ObjectId "1b993954-3377-46fd-a368-58fff7420021" | Where-Object {$_.Scope -eq "/subscriptions/$script:subscriptionId" -and $_.RoleDefinitionId -eq "acdd72a7-3385-48ef-bd42-f606fba81ae7"})
-        $script:routeTable = (Get-AzRouteTable -ResourceGroupName $($script:resourceGroup).ResourceGroupName -Name "RouteTable")
-        
+        $script:routeTable = (Get-AzResource -Name "RouteTable" -ResourceGroupName $($script:resourceGroup).ResourceGroupName)
+
         #
         # Invoke the Invoke-AzOpsPull
         # function to generate the scope data which

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -101,7 +101,7 @@ Describe "Repository" {
         #>
 
         $script:managementGroupDeployment = (Get-AzManagementGroupDeployment -ManagementGroupId "$script:tenantId" -Name "AzOps-Tests")
-        $script:timeOutMinutes = 20
+        $script:timeOutMinutes = 25
         $script:mgmtRun = "Run"
 
         While ($script:mgmtRun -eq "Run") {

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -144,12 +144,18 @@ Describe "Repository" {
         # the filesystem are aligned.
         #
 
-        $script:policyAssignments = Get-AzPolicyAssignment -Name "TestPolicyAssignment" -Scope "/providers/Microsoft.Management/managementGroups/$($script:managementManagementGroup.Name)"
-        $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)
-        $script:resourceGroup = (Get-AzResourceGroup | Where-Object ResourceGroupName -eq "Application")
-        $script:roleAssignments = (Get-AzRoleAssignment -ObjectId "1b993954-3377-46fd-a368-58fff7420021" | Where-Object { $_.Scope -eq "/subscriptions/$script:subscriptionId" -and $_.RoleDefinitionId -eq "acdd72a7-3385-48ef-bd42-f606fba81ae7" })
-        $script:routeTable = (Get-AzResource -Name "RouteTable" -ResourceGroupName $($script:resourceGroup).ResourceGroupName)
-
+        try {
+            Set-AzContext -SubscriptionId $script:subscriptionId
+            $script:policyAssignments = Get-AzPolicyAssignment -Name "TestPolicyAssignment" -Scope "/providers/Microsoft.Management/managementGroups/$($script:managementManagementGroup.Name)"
+            $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)
+            $script:resourceGroup = (Get-AzResourceGroup | Where-Object ResourceGroupName -eq "Application")
+            $script:roleAssignments = (Get-AzRoleAssignment -ObjectId "1b993954-3377-46fd-a368-58fff7420021" | Where-Object { $_.Scope -eq "/subscriptions/$script:subscriptionId" -and $_.RoleDefinitionId -eq "acdd72a7-3385-48ef-bd42-f606fba81ae7" })
+            $script:routeTable = (Get-AzResource -Name "RouteTable" -ResourceGroupName $($script:resourceGroup).ResourceGroupName)
+        }
+        catch {
+            Write-PSFMessage -Level Critical -Message "Failed to get deployed services" -Exception $_.Exception
+        }
+        
         #
         # Invoke the Invoke-AzOpsPull
         # function to generate the scope data which

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -145,6 +145,7 @@ Describe "Repository" {
         #
 
         try {
+            Start-Sleep -Seconds 300
             Set-AzContext -SubscriptionId $script:subscriptionId
             $script:policyAssignments = Get-AzPolicyAssignment -Name "TestPolicyAssignment" -Scope "/providers/Microsoft.Management/managementGroups/$($script:managementManagementGroup.Name)"
             $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)

--- a/src/tests/templates/azuredeploy.jsonc
+++ b/src/tests/templates/azuredeploy.jsonc
@@ -84,6 +84,35 @@
                 "[resourceId('Microsoft.Management/managementGroups', guid('Platform'))]"
             ]
         },
+        // Policy Assignment - Test - Platform - Management
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2020-10-01",
+            "name": "Test-Policy-Assignment-Nested",
+            "location": "northeurope",
+            "dependsOn": [
+                "[resourceId('Microsoft.Management/managementGroups', guid('Management'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                        {
+                            "type": "Microsoft.Authorization/policyAssignments",
+                            "apiVersion": "2021-06-01",
+                            "name": "TestPolicyAssignment",
+                            "properties": {
+                                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0a914e76-4921-4c19-b460-a2d36003525a"
+                            }
+                        }
+                    ],
+                    "outputs": {}
+                }
+            },
+            "scope": "[concat('Microsoft.Management/managementGroups/', guid('Management'))]"
+        },
         // Subscription - Test - Platform - Management - Subscription-0
         {
             "type": "Microsoft.Management/managementGroups/subscriptions",
@@ -94,7 +123,7 @@
                 "[resourceId('Microsoft.Management/managementGroups', guid('Management'))]"
             ]
         },
-        // Resource Group - Test - Platform - Management - Subscription-0 - Application
+        // Resource Group, Role Assignment and Route Table - Test - Platform - Management - Subscription-0 - Application
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
@@ -112,6 +141,47 @@
                             "apiVersion": "2019-10-01",
                             "name": "Application",
                             "location": "northeurope"
+                        },
+                        {
+                            "type": "Microsoft.Authorization/roleAssignments",
+                            "apiVersion": "2021-04-01-preview",
+                            "name": "[guid('RoleAssignmentTest')]",
+                            "properties": {
+                                "roleDefinitionId": "[concat('/subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Authorization/roleDefinitions/', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                                "principalId": "1b993954-3377-46fd-a368-58fff7420021"
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Resources/deployments",
+                            "apiVersion": "2019-10-01",
+                            "name": "RouteTable",
+                            "resourceGroup": "Application",
+                            "dependsOn": [
+                                "Application"
+                            ],
+                            "properties": {
+                                "mode": "Incremental",
+                                "expressionEvaluationOptions": {
+                                    "scope": "inner"
+                                },
+                                "template": {
+                                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                                    "contentVersion": "1.0.0.0",
+                                    "resources": [
+                                        {
+                                            "apiVersion": "2019-02-01",
+                                            "type": "Microsoft.Network/routeTables",
+                                            "name": "RouteTable",
+                                            "location": "northeurope",
+                                            "properties": {
+                                                "disableBgpRoutePropagation": "false"
+                                            }
+                                        }
+                                    ],
+                                    "outputs": {
+                                    }
+                                }
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
## Overview/Summary

To increase confidence in changes to the codebase this PR adds additional automated tests to validate three pull operations:

1. Policy assignment at management group scope
2. Role assignment at subscription scope
3. Resource deployment at resource group scope

## This PR fixes/adds/changes/removes

1. Adds deployment of a policy assignment
2. Adds deployment of a role assignment
3. Adds deployment of a resource deployment
4. Adds Pester tests to validate resource discovery
5. Adds logic to remove role assignment at subscription scope for service principal at cleanup
6. Changes the AzOpsPull operation, it performs a discovery which includes roles, policy's and resources to enable the extended tests
7. Fixes spelling output

### Breaking Changes

N/A

## Testing Evidence

Performed a full run of Pester tests resulting in successful deployment and discovery of resources at desired scopes.
Performed a full run of Pester tests resulting in successful deployment and intended failure of resource discovery which the test alerted to for each of the three new scope/types.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.