### PR TITLE
PowerShell 7.2 requirement and PSStyle.OutputRendering set to Host

### DIFF
--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) Microsoft. All rights reserved.'
 Description = 'Integrated CI/CD Solution for Microsoft Azure.'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '7.0'
+PowerShellVersion = '7.2'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -47,6 +47,7 @@
     )
 
     begin {
+        $PSStyle.OutputRendering = [System.Management.Automation.OutputRendering]::Host
         Assert-AzOpsWindowsLongPath -Cmdlet $PSCmdlet
         Assert-AzOpsJqDependency -Cmdlet $PSCmdlet
 

--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -47,7 +47,9 @@
     )
 
     begin {
+        # Change PSSStyle output rendering to Host to remove escape sequences are removed in redirected or piped output.
         $PSStyle.OutputRendering = [System.Management.Automation.OutputRendering]::Host
+        # Assert dependencies
         Assert-AzOpsWindowsLongPath -Cmdlet $PSCmdlet
         Assert-AzOpsJqDependency -Cmdlet $PSCmdlet
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Closing #505 related to https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals?view=powershell-7.2  that was introduced in PowerShell 7.2
![image](https://user-images.githubusercontent.com/16622613/147471437-8009b60d-e5cd-4f81-b216-4a6cb816b297.png)

$PSStyle.OutputRendering set to Host instead of default ANSI to remove ANSI escape sequences in redirected or piped output. 

### Breaking Changes

1. PowerShell 7.2 is now a requirement 

## Testing Evidence
Before fix: 
![image](https://user-images.githubusercontent.com/16622613/147470220-ae133b0f-9ed0-4b5a-a87b-5d9e5139cb3e.png)

After fix: 
![image](https://user-images.githubusercontent.com/16622613/147469912-f8193665-03fc-4b06-a826-0f5b2dccd4c3.png)

