### PR TITLE
Condition to avoid duplicate bicep deployments using parameter files

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -226,7 +226,7 @@
 
             # Avoid duplicate entries in the deployment list
             if ($addition.EndsWith(".parameters.json")) {
-                if ($addModifySet -contains $addition.Replace(".parameters.json", ".json")) {
+                if ($addModifySet -contains $addition.Replace(".parameters.json", ".json") -or $addModifySet -contains $addition.Replace(".parameters.json", ".bicep")) {
                     continue
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Expanded condition that was already in place for ARM templates to avoid creating duplicate deployment entries when submitting bicep templates with parameter files. 
Closing #504 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.