### PR TITLE
Adding linting for Markdown files

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,35 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 1000            # Line length 80 is far to short
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,32 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: "Lint Code Base"
+
+on:
+  push:
+    branches: [ main ]
+    
+  pull_request:
+    branches: [ main ]
+    
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_INCLUDE: .*.md

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,7 +7,7 @@
 name: "Lint Code Base"
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 jobs:
@@ -17,8 +17,6 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,12 +7,9 @@
 name: "Lint Code Base"
 
 on:
-  push:
+  pull_request_target:
     branches: [ main ]
-    
-  pull_request:
-    branches: [ main ]
-    
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,19 +8,21 @@ name: "Lint Code Base"
 
 on:
   pull_request_target:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   run-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: "Checkout code"
         uses: actions/checkout@v2
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Lint Code Base
+      - name: "Lint Code Base"
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: "AzOps - Tests"
 
 on:
   workflow_dispatch:
-  
+
   pull_request_target:
     branches: [main]
     paths:
@@ -13,7 +13,7 @@ permissions:
       id-token: write
       contents: write
       pull-requests: write
-      
+
 jobs:
   tests:
     name: "Tests"
@@ -24,7 +24,7 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      
+
     steps:
 
       # Checkout
@@ -40,23 +40,16 @@ jobs:
         shell: pwsh
         run: |
           ./scripts/Dependencies.ps1
-      
-      # Connect to Azure - TEMPORARY until 2.7.0 credential expiration issue is fixed 
-      - name: "Connect"
-        shell: pwsh
-        run: |
-          $credential = New-Object PSCredential -ArgumentList $env:ARM_CLIENT_ID, (ConvertTo-SecureString -String $env:ARM_CLIENT_SECRET -AsPlainText -Force)
-          Connect-AzAccount -TenantId $env:ARM_TENANT_ID -ServicePrincipal -Credential $credential -SubscriptionId $env:ARM_SUBSCRIPTION_ID
-          
-    # # Authenticate Azure context   
-    # - name: OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
-    #   uses: azure/login@v1
-    #   with:
-    #     client-id: ${{ env.ARM_CLIENT_ID}}
-    #     tenant-id: ${{ env.ARM_TENANT_ID }}
-    #     subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }} 
-    #     enable-AzPSSession: true
-      
+
+     # Authenticate Azure context   
+      - name: OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID}}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }} 
+          enable-AzPSSession: true
+
       # Run Tests   
       - name: "Run Tests"
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -3,21 +3,23 @@
 ![GitHub issues by-label](https://img.shields.io/github/issues/azure/azops/enhancement?label=enhancement%20issues)
 ![GitHub issues by-label](https://img.shields.io/github/issues/azure/azops/bug?label=bug%20issues)
 ![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/azops)
+![GitHub Super-Linter](https://github.com/Azure/AzOps/workflows/AzOps%20-%20Tests/badge.svg)
+![GitHub Super-Linter](https://github.com/Azure/AzOps/workflows/Lint%20Code%20Base/badge.svg)
 
 This repository is for active development of the AzOps PowerShell cmdlets.
 
-### Getting started
+## Getting started
 
 For tutorials, samples and quick starts, visit the [AzOps Accelerator](https://github.com/azure/azops-accelerator) template repository.
 
-### Dependencies
+## Dependencies
 
 - [Az.Accounts](https://github.com/azure/azure-powershell)
 - [Az.Billing](https://github.com/azure/azure-powershell)
 - [Az.Resources](https://github.com/azure/azure-powershell)
 - [PSFramework](https://github.com/PowershellFrameworkCollective/psframework)
 
-### Need help?
+## Need help?
 
 For introduction guidance visit the [GitHub Wiki](https://github.com/azure/azops/wiki)  
 For reference documentation visit the [Enterprise-Scale](https://github.com/azure/enterprise-scale)  
@@ -26,9 +28,11 @@ For information on contributing to the module, visit the [Contributing Guide](ht
 For information on migrating to the new version, visit the [Migration Guide](https://github.com/azure/azops/wiki/migration)  
 File an issue via [GitHub Issues](https://github.com/azure/azops/issues/new/choose)  
 
-### Output
+## Output
 
-AzOps is rooted in the principle that everything in Azure is a resource and to operate at-scale, it should be managed declaratively to determine target goal state of the overall platform. This PowerShell module provides the ability to deploy Resource Templates & Bicep files at all Azure [scope](https://docs.microsoft.com/azure/role-based-access-control/scope-overview) levels. To provide this functionality the multiple scopes within Azure Resource Manager are represented (example below) within Git. Using directories and files, templates can be deployed (Push) at various scopes whilst also exporting (Pull) composite templates from ARM and placing them within the repository.
+AzOps is rooted in the principle that everything in Azure is a resource and to operate at-scale, it should be managed declaratively to determine target goal state of the overall platform.
+
+This PowerShell module provides the ability to deploy Resource Templates & Bicep files at all Azure [scope](https://docs.microsoft.com/azure/role-based-access-control/scope-overview) levels. To provide this functionality the multiple scopes within Azure Resource Manager are represented (example below) within Git. Using directories and files, templates can be deployed (Push) at various scopes whilst also exporting (Pull) composite templates from ARM and placing them within the repository.
 
 ```bash
 root
@@ -65,11 +69,11 @@ root
                 └── microsoft.resources_resourcegroups-networks.json
 ```
 
-### Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -79,7 +83,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-### Trademarks
+## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
 trademarks or logos is subject to and must follow


### PR DESCRIPTION
## Overview/Summary

Added pipeline to use < https://github.com/github/super-linter>.
At this time it will only lint Markdown files, fixes #525

## This PR fixes/adds/changes/removes

1. Adds GitHub Action "Lint Code Base"
2. Update README.md with status badge and some syntax errors found with super-linter
3. Update AzOps - Test to use OIDC

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.