### PR TITLE
Update jq filter for policyAssignments to exclude UMI and change IdentityType to Type

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -19,5 +19,5 @@
         }
     ],
     "outputs": {}
-} |
-.resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end
+} | .resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end | 
+ .resources[] |= if .identity.IdentityType !=null then .identity["Type"] = .identity.IdentityType | del(.identity.IdentityType) else . end

--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -20,4 +20,4 @@
     ],
     "outputs": {}
 } |
-.resources[] |= if .identity==null then del(.identity) else . end
+.resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Updated jq filter for policyAssignments to exclude Identities.UserManagedIdentity property when it is not being used. 
Also updated filter to change identity.IdentityType to Identity.Type
Closing #529. 

## Testing Evidence

JQ filter validation done @ https://jqplay.org/s/FetEy603yQ
Successful test run from branch: 
![image](https://user-images.githubusercontent.com/16622613/149491541-5837ff69-44c1-40cd-a991-0fd2ee473edd.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.