### PR TITLE
updated jq filter for policyAssignments with UMI

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -20,8 +20,5 @@
     ],
     "outputs": {}
 } | .resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end | 
- .resources[] |= if .identity.IdentityType !=null then .identity["Type"] = .identity.IdentityType | del(.identity.IdentityType) else . end |
- .resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end |
- .resources[] |= if .identity.UserAssignedIdentities != null then del( .identity.UserAssignedIdentities[].PrincipalId?, .identity.UserAssignedIdentities[].ClientId?, .identity.ClientId?, .identity.PrincipalId?) else . end |
- .resources[] |= if .identity.PrincipalId == null then del(.identity.PrincipalId) else . end |
- .resources[] |= if .identity.TenantId == null then del(.identity.TenantId) else . end
+.resources[] |= if .identity.IdentityType !=null then .identity["Type"] = .identity.IdentityType | del(.identity.IdentityType) else . end |
+.resources[] |= if .identity.UserAssignedIdentities != null then del(.identity.UserAssignedIdentities[].PrincipalId, .identity.UserAssignedIdentities[].ClientId, .identity.TenantId, .identity.PrincipalId) else . end

--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -20,4 +20,8 @@
     ],
     "outputs": {}
 } | .resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end | 
- .resources[] |= if .identity.IdentityType !=null then .identity["Type"] = .identity.IdentityType | del(.identity.IdentityType) else . end
+ .resources[] |= if .identity.IdentityType !=null then .identity["Type"] = .identity.IdentityType | del(.identity.IdentityType) else . end |
+ .resources[] |= if .identity==null then del(.identity) elif .identity.UserAssignedIdentities==null then del(.identity.UserAssignedIdentities) else . end |
+ .resources[] |= if .identity.UserAssignedIdentities != null then del( .identity.UserAssignedIdentities[].PrincipalId?, .identity.UserAssignedIdentities[].ClientId?, .identity.ClientId?, .identity.PrincipalId?) else . end |
+ .resources[] |= if .identity.PrincipalId == null then del(.identity.PrincipalId) else . end |
+ .resources[] |= if .identity.TenantId == null then del(.identity.TenantId) else . end


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update jq filter for policyAssignment with UMI. In this case
1) identity.PrincipalId and identity.TenantId are both null and can be removed
2) UserAssignedIdentities should only contain (according to validation error) "the resource exisiting property" (sic) so removing PrincipalId and ClientId from it

## This PR fixes/adds/changes/removes

1. #538 

### Breaking Changes
None identified.

## Testing Evidence
I'm new to 'jq' and only tweaked the jq filter as such and did not rebuild the PowerShell module as a whole.

JQ filter validation done @ https://jqplay.org/s/kM2UYiFcvd

I expect some feedback on that jg logic... ;-) 

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
