### PR TITLE
removed excessive parameter, code cleanup.

### DIFF
--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -22,7 +22,6 @@
         .PARAMETER PartialMgDiscoveryRoot
             Custom search roots under which to detect management groups.
             Used for partial management group discovery.
-            Must be used in combination with -PartialMgDiscovery
         .EXAMPLE
             > Initialize-AzOpsEnvironment
             Initializes the default execution context of the module.

--- a/src/functions/Invoke-AzOpsPull.ps1
+++ b/src/functions/Invoke-AzOpsPull.ps1
@@ -83,7 +83,7 @@
             }
         }
 
-        $parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Inherit -Include InvalidateCache, PartialMgDiscovery, PartialMgDiscoveryRoot
+        $parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Inherit -Include InvalidateCache, PartialMgDiscoveryRoot
         Initialize-AzOpsEnvironment @parameters
 
         Assert-AzOpsInitialization -Cmdlet $PSCmdlet -StatePath $StatePath


### PR DESCRIPTION
# Overview/Summary
Removed the excessive (non-existing) parameter PartialMgDiscovery when calling Initialize-AzOpsEnvironment.

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/AzOps/issues/290

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
