### PR TITLE
Fix managed identity lookup in Remove-AzOpsDeployment

### DIFF
--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -96,19 +96,8 @@
         }
 
         #region Validate root '/' permissions - different methods of getting current context depending on principalType
-        switch ($currentAzContext.Account.Type) {
-            'User' {
-                $rootPermissions = Get-AzRoleAssignment -UserPrincipalName $currentAzContext.Account.Id -Scope "/" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-            }
-            'ManagedService' {
-                # Get managed identity application id via IMDS (https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token)
-                $applicationId = (Invoke-RestMethod -Uri "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F" -Headers @{ Metadata = $true }).client_id
-                $rootPermissions = Get-AzRoleAssignment -ObjectId (Get-AzADServicePrincipal -ApplicationId $applicationId).Id -Scope "/" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-            }
-            'ServicePrincipal' {
-                $rootPermissions = Get-AzRoleAssignment -ObjectId (Get-AzADServicePrincipal -ApplicationId $currentAzContext.Account.Id).Id -Scope "/" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
-            }
-        }
+        $currentPrincipal = Get-AzOpsCurrentPrincipal -AzContext $currentAzContext
+        $rootPermissions = Get-AzRoleAssignment -ObjectId $currentPrincipal.id -Scope "/" -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
 
         if (-not $rootPermissions) {
             Write-PSFMessage -Level Important -String 'Initialize-AzOpsEnvironment.ManagementGroup.NoRootPermissions' -StringValues $currentAzContext.Account.Id

--- a/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
+++ b/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
@@ -1,4 +1,4 @@
-function Get-AzOpsCurrentPrincipal {
+﻿function Get-AzOpsCurrentPrincipal {
     <#
         .SYNOPSIS
             Gets the objectid/clientid from the current Azure context

--- a/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
+++ b/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
@@ -1,0 +1,38 @@
+function Get-AzOpsCurrentPrincipal {
+    <#
+        .SYNOPSIS
+            Gets the objectid/clientid from the current Azure context
+        .DESCRIPTION
+            Gets the objectid/clientid from the current Azure context
+        .PARAMETER Cmdlet
+            The $PSCmdlet variable of the calling command.
+        .EXAMPLE
+            > Get-AzOpsCurrentPrincipal -AzContext $AzContext
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        $AzContext = (Get-AzContext)
+    )
+
+    process {
+        Write-PSFMessage -Level InternalComment -String 'Get-AzOpsCurrentPrincipal.AccountType' -StringValues $AzContext.Account.Type
+
+        switch ($AzContext.Account.Type) {
+            'User' {
+                $principalObject = (Invoke-AzRestMethod -Uri https://graph.microsoft.com/v1.0/me).Content | ConvertFrom-Json
+            }
+            'ManagedService' {
+                # Get managed identity application id via IMDS (https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token)
+                $applicationId = (Invoke-RestMethod -Uri "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F" -Headers @{ Metadata = $true }).client_id
+                $principalObject = Get-AzADServicePrincipal -ApplicationId $applicationId
+            }
+            'ServicePrincipal' {
+                $principalObject = Get-AzADServicePrincipal -ApplicationId $AzContext.Account.Id
+            }
+        }
+        Write-PSFMessage -Level InternalComment -String 'Get-AzOpsCurrentPrincipal.PrincipalId' -StringValues $principalObject.Id
+        return $principalObject
+    }
+}

--- a/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
+++ b/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
@@ -4,8 +4,8 @@
             Gets the objectid/clientid from the current Azure context
         .DESCRIPTION
             Gets the objectid/clientid from the current Azure context
-        .PARAMETER Cmdlet
-            The $PSCmdlet variable of the calling command.
+        .PARAMETER AzContext
+            The AzContext used when pulling the information.
         .EXAMPLE
             > Get-AzOpsCurrentPrincipal -AzContext $AzContext
     #>

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -63,8 +63,7 @@
         #endregion SetContext
 
         #GetContext
-        $context = Get-AzContext
-        $contextObjectId = (Get-AzADServicePrincipal -ApplicationId $context.Account.id).Id
+        $contextObjectId = Get-AzOpsCurrentPrincipal
         #region PolicyAssignment
         if ($scopeObject.Resource -eq "policyAssignments") {
             #Validate
@@ -80,7 +79,7 @@
                 return
             }
             elseif ((-not $roleAssignmentPermissionCheck)) {
-                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $context.Account.Id, $scopeObject.Scope -Target $scopeObject
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $contextObjectId, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName, $scopeObject.scope
                 Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
                 return
@@ -117,7 +116,7 @@
                 return
             }
             elseif (-not $roleAssignmentPermissionCheck) {
-                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $context.Account.Id, $scopeObject.Scope -Target $scopeObject
+                Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $contextObjectId, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Failed: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName, $templateContent.resources[0].properties.PrincipalId, $roleAssignment.Scope, $templateContent.resources[0].properties.RoleDefinitionName
                 Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
                 return

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -63,7 +63,7 @@
         #endregion SetContext
 
         #GetContext
-        $contextObjectId = Get-AzOpsCurrentPrincipal
+        $contextObjectId = (Get-AzOpsCurrentPrincipal).id
         #region PolicyAssignment
         if ($scopeObject.Resource -eq "policyAssignments") {
             #Validate

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -79,8 +79,11 @@
     'ConvertTo-AzOpsState.ObjectType.Resolved.ResourceType'                         = 'Determined object type based on resourceType {0}' # $Resource.ResourceType
     'ConvertTo-AzOpsState.Jq.Remove'                                                = 'Using Jq Remove Template at path {0}'# jqRemoveTemplate
     'ConvertTo-AzOpsState.Jq.Template'                                              = 'Using Jq Json Template at path {0}'# jqRemoveTemplate
-    'ConvertTo-AzOpsState.Subscription.ChildResource.Jq.Template'                  = 'Using Jq Json Template at path {0}' # $jqJsonTemplate
-    'ConvertTo-AzOpsState.Subscription.ChildResource.Exporting'                    = 'Exporting AzOpsState to {0}' # $resourceData.ObjectFilePath'
+    'ConvertTo-AzOpsState.Subscription.ChildResource.Jq.Template'                   = 'Using Jq Json Template at path {0}' # $jqJsonTemplate
+    'ConvertTo-AzOpsState.Subscription.ChildResource.Exporting'                     = 'Exporting AzOpsState to {0}' # $resourceData.ObjectFilePath'
+
+    'Get-AzOpsCurrentPrincipal.AccountType'                                         = 'Current AccountType is {0}' #$AzContext.Account.Type
+    'Get-AzOpsCurrentPrincipal.PrincipalId'                                         = 'Current PrincipalId is {0}' #$principalObject.id
 
     'Get-AzOpsPolicyAssignment.ManagementGroup'                                     = 'Retrieving Policy Assignment for Management Group {0} ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
     'Get-AzOpsPolicyAssignment.ResourceGroup'                                       = 'Retrieving Policy Assignment for Resource Group {0}' # $ScopeObject.ResourceGroup
@@ -89,9 +92,9 @@
     'Get-AzOpsPolicyDefinition.ManagementGroup'                                     = 'Retrieving custom policy definitions for Management Group [{0}] ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
     'Get-AzOpsPolicyDefinition.Subscription'                                        = 'Retrieving custom policy definitions for Subscription [{0}] ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
 
-    'Get-AzOpsPolicyExemption.ManagementGroup'                                     = 'Retrieving Policy Exemption for Management Group {0} ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
-    'Get-AzOpsPolicyExemption.ResourceGroup'                                       = 'Retrieving Policy Exemption for Resource Group {0}' # $ScopeObject.ResourceGroup
-    'Get-AzOpsPolicyExemption.Subscription'                                        = 'Retrieving Policy Exemption for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
+    'Get-AzOpsPolicyExemption.ManagementGroup'                                      = 'Retrieving Policy Exemption for Management Group {0} ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
+    'Get-AzOpsPolicyExemption.ResourceGroup'                                        = 'Retrieving Policy Exemption for Resource Group {0}' # $ScopeObject.ResourceGroup
+    'Get-AzOpsPolicyExemption.Subscription'                                         = 'Retrieving Policy Exemption for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
 
     'Get-AzOpsPolicySetDefinition.ManagementGroup'                                  = 'Retrieving PolicySet Definition for ManagementGroup {0} ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
     'Get-AzOpsPolicySetDefinition.Subscription'                                     = 'Retrieving PolicySet Definition for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
@@ -146,38 +149,38 @@
     'Initialize-AzOpsEnvironment.Processing.Completed'                              = 'AzOps environment initialization concluded' #
     'Initialize-AzOpsEnvironment.UsingCache'                                        = 'Using cached values for AzOpsAzManagementGroup and AzOpsSubscriptions' #
 
-    'Invoke-AzOpsPull.Deleting.State'                                     = 'Removing state in {0}' # $StatePath
-    'Invoke-AzOpsPull.Duration'                                           = 'AzOps repository setup completed in {0}' # $stopWatch.Elapsed
-    'Invoke-AzOpsPull.Initialization.Completed'                           = 'Completed preparations for the AzOps repository setup' #
-    'Invoke-AzOpsPull.Initialization.Starting'                            = 'Starting preparations for the AzOps repository setup' #
-    'Invoke-AzOpsPull.Migration.Required'                                 = 'Migration from previous repository state IS required' #
-    'Invoke-AzOpsPull.Rebuilding.State'                                   = 'Rebuilding state in {0}' # $StatePath
-    'Invoke-AzOpsPull.Tenant'                                             = 'Connected to tenant {0}' # $tenantId
-    'Invoke-AzOpsPull.TemplateParameterFileSuffix'                        = 'Connected to tenant {0}' # $TemplateParameterFileSuffix
-    'Invoke-AzOpsPull.Validating.UserRole'                                = 'Asserting fundamental Azure access' #
-    'Invoke-AzOpsPull.Validating.UserRole.Failed'                         = 'Insufficient access to Azure user data' #
-    'Invoke-AzOpsPull.Validating.UserRole.Success'                        = 'Azure access validated' #
+    'Invoke-AzOpsPull.Deleting.State'                                               = 'Removing state in {0}' # $StatePath
+    'Invoke-AzOpsPull.Duration'                                                     = 'AzOps repository setup completed in {0}' # $stopWatch.Elapsed
+    'Invoke-AzOpsPull.Initialization.Completed'                                     = 'Completed preparations for the AzOps repository setup' #
+    'Invoke-AzOpsPull.Initialization.Starting'                                      = 'Starting preparations for the AzOps repository setup' #
+    'Invoke-AzOpsPull.Migration.Required'                                           = 'Migration from previous repository state IS required' #
+    'Invoke-AzOpsPull.Rebuilding.State'                                             = 'Rebuilding state in {0}' # $StatePath
+    'Invoke-AzOpsPull.Tenant'                                                       = 'Connected to tenant {0}' # $tenantId
+    'Invoke-AzOpsPull.TemplateParameterFileSuffix'                                  = 'Connected to tenant {0}' # $TemplateParameterFileSuffix
+    'Invoke-AzOpsPull.Validating.UserRole'                                          = 'Asserting fundamental Azure access' #
+    'Invoke-AzOpsPull.Validating.UserRole.Failed'                                   = 'Insufficient access to Azure user data' #
+    'Invoke-AzOpsPull.Validating.UserRole.Success'                                  = 'Azure access validated' #
 
-    'Invoke-AzOpsPush.Change.AddModify'                                           = 'Adding or modifying:' #
-    'Invoke-AzOpsPush.Change.AddModify.File'                                      = '  {0}' # $item
-    'Invoke-AzOpsPush.Change.Delete'                                              = 'Deleting:' #
-    'Invoke-AzOpsPush.Change.Delete.File'                                         = '  {0}' # $item
-    'Invoke-AzOpsPush.Deploy.ProviderFeature'                                     = 'Invoking new state deployment - *.providerfeatures.json for a file {0}' # $addition
-    'Invoke-AzOpsPush.Deploy.ResourceProvider'                                    = 'Invoking new state deployment - *.resourceproviders.json for a file {0}' # $addition
-    'Invoke-AzOpsPush.Deploy.Subscription'                                        = 'Invoking new state deployment - *.subscription.json for a file {0}' # $addition
-    'Invoke-AzOpsPush.Deployment.Required'                                        = 'Deployment required' #
-    'Invoke-AzOpsPush.Resolve.ConvertBicepTemplate'                               = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $FilePath, $templatePath
-    'Invoke-AzOpsPush.Resolve.FoundTemplate'                                      = 'Found template {1} for parameters {0}' # $FilePath, $templatePath
-    'Invoke-AzOpsPush.Resolve.FoundBicepTemplate'                                 = 'Found Bicep template {1} for parameters {0}' # $FilePath, $templatePath
-    'Invoke-AzOpsPush.Resolve.FromMainTemplate'                                   = 'Determining template from main template file: {0}' # $mainTemplateItem.FullName
-    'Invoke-AzOpsPush.Resolve.MainTemplate.NotSupported'                          = 'effectiveResourceType: {0} AzOpsMainTemplate does NOT supports resource type {0} in {1}. Deployment will be ignored' # $effectiveResourceType, $AzOpsMainTemplate.FullName
-    'Invoke-AzOpsPush.Resolve.MainTemplate.Supported'                             = 'effectiveResourceType: {0} - AzOpsMainTemplate supports resource type {0} in {1}' # $effectiveResourceType, $AzOpsMainTemplate.FullName
-    'Invoke-AzOpsPush.Resolve.NoJson'                                             = 'The specified file is not a json file at all! Skipping {0}' # $fileItem.FullName
-    'Invoke-AzOpsPush.Resolve.NotFoundTemplate'                                   = 'Did NOT find template {1} for parameters {0}' # $FilePath, $templatePath
-    'Invoke-AzOpsPush.Resolve.ParameterFound'                                     = 'Found parameter file for template {0} : {1}' # $FilePath, $parameterPath
-    'Invoke-AzOpsPush.Resolve.ParameterNotFound'                                  = 'No parameter file found for template {0} : {1}' # $FilePath, $parameterPath
-    'Invoke-AzOpsPush.Scope.Failed'                                               = 'Failed to read {0} as part of {1}' # $addition, $StatePath
-    'Invoke-AzOpsPush.Scope.NotFound'                                             = 'Skipping {0}, not part of {1}' # $addition, $StatePath
+    'Invoke-AzOpsPush.Change.AddModify'                                             = 'Adding or modifying:' #
+    'Invoke-AzOpsPush.Change.AddModify.File'                                        = '  {0}' # $item
+    'Invoke-AzOpsPush.Change.Delete'                                                = 'Deleting:' #
+    'Invoke-AzOpsPush.Change.Delete.File'                                           = '  {0}' # $item
+    'Invoke-AzOpsPush.Deploy.ProviderFeature'                                       = 'Invoking new state deployment - *.providerfeatures.json for a file {0}' # $addition
+    'Invoke-AzOpsPush.Deploy.ResourceProvider'                                      = 'Invoking new state deployment - *.resourceproviders.json for a file {0}' # $addition
+    'Invoke-AzOpsPush.Deploy.Subscription'                                          = 'Invoking new state deployment - *.subscription.json for a file {0}' # $addition
+    'Invoke-AzOpsPush.Deployment.Required'                                          = 'Deployment required' #
+    'Invoke-AzOpsPush.Resolve.ConvertBicepTemplate'                                 = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $FilePath, $templatePath
+    'Invoke-AzOpsPush.Resolve.FoundTemplate'                                        = 'Found template {1} for parameters {0}' # $FilePath, $templatePath
+    'Invoke-AzOpsPush.Resolve.FoundBicepTemplate'                                   = 'Found Bicep template {1} for parameters {0}' # $FilePath, $templatePath
+    'Invoke-AzOpsPush.Resolve.FromMainTemplate'                                     = 'Determining template from main template file: {0}' # $mainTemplateItem.FullName
+    'Invoke-AzOpsPush.Resolve.MainTemplate.NotSupported'                            = 'effectiveResourceType: {0} AzOpsMainTemplate does NOT supports resource type {0} in {1}. Deployment will be ignored' # $effectiveResourceType, $AzOpsMainTemplate.FullName
+    'Invoke-AzOpsPush.Resolve.MainTemplate.Supported'                               = 'effectiveResourceType: {0} - AzOpsMainTemplate supports resource type {0} in {1}' # $effectiveResourceType, $AzOpsMainTemplate.FullName
+    'Invoke-AzOpsPush.Resolve.NoJson'                                               = 'The specified file is not a json file at all! Skipping {0}' # $fileItem.FullName
+    'Invoke-AzOpsPush.Resolve.NotFoundTemplate'                                     = 'Did NOT find template {1} for parameters {0}' # $FilePath, $templatePath
+    'Invoke-AzOpsPush.Resolve.ParameterFound'                                       = 'Found parameter file for template {0} : {1}' # $FilePath, $parameterPath
+    'Invoke-AzOpsPush.Resolve.ParameterNotFound'                                    = 'No parameter file found for template {0} : {1}' # $FilePath, $parameterPath
+    'Invoke-AzOpsPush.Scope.Failed'                                                 = 'Failed to read {0} as part of {1}' # $addition, $StatePath
+    'Invoke-AzOpsPush.Scope.NotFound'                                               = 'Skipping {0}, not part of {1}' # $addition, $StatePath
 
     'Invoke-AzOpsNativeCommand.Failed.NoCallstack'                                  = 'Execution of {{{0}}} failed with exit code {1}' # $ScriptBlock, $LASTEXITCODE
     'Invoke-AzOpsNativeCommand.Failed.WithCallstack'                                = 'Execution of {{{0}}} by {1}: line {2} failed with exit code {3}' # $ScriptBlock, $caller[1].ScriptName, $caller[1].ScriptLineNumber, $LASTEXITCODE

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -259,6 +259,16 @@ Describe "Repository" {
             "A`t$script:ruleCollectionGroupsFile"
         )
         Invoke-AzOpsPush -ChangeSet $changeSet
+
+        #Test deletion of supported resources
+        $changeSet = @(
+            "D`t$script:policyAssignmentsFile",
+            "D`t$script:roleAssignmentsFile"
+        )
+        $DeleteSetContents += (Get-Content $Script:policyAssignmentsFile)
+        $DeleteSetContents += '-- '
+        $DeleteSetContents += (Get-Content $Script:roleAssignmentsFile)
+        Invoke-AzOpsPush -ChangeSet $changeSet -DeleteSetContents $deleteSetContents
     }
 
     Context "Test" {
@@ -446,6 +456,10 @@ Describe "Repository" {
             $script:policyAssignmentDeployment = Get-AzManagementGroupDeployment -ManagementGroupId $script:managementManagementGroup.Name -Name $script:policyAssignmentsDeploymentName
             $policyAssignmentDeployment.ProvisioningState | Should -Be "Succeeded"
         }
+        It "Policy Assignments deletion should be successful" {
+            $policyAssignmentDeletion = Get-AzPolicyAssignment -Id $script:policyAssignments.PolicyAssignmentId -ErrorAction SilentlyContinue
+            $policyAssignmentDeletion | Should -Be $Null
+        }
         #endregion
 
         #region Scope - Subscription (./root/tenant root group/test/platform/management/subscription-0)
@@ -540,6 +554,10 @@ Describe "Repository" {
         It "Role Assignment deployment should be successful" {
             $script:roleAssignmentDeployment = Get-AzSubscriptionDeployment -Name $script:roleAssignmentsDeploymentName
             $roleAssignmentDeployment.ProvisioningState | Should -Be "Succeeded"
+        }
+        It "Role Assignment deletion should be successful" {
+            $roleAssignmentDeletion = (Get-AzRoleAssignment -ObjectId "1b993954-3377-46fd-a368-58fff7420021" | Where-Object { $_.Scope -eq "/subscriptions/$script:subscriptionId" -and $_.RoleDefinitionId -eq "acdd72a7-3385-48ef-bd42-f606fba81ae7" })
+            $roleAssignmentDeletion | Should -Be $Null
         }
         #endregion
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Additional fix for #533 related to `Remove-AzOpsDeployment`. 

- Created separate function to determine current principaltype/principalId
 - Updated `Initialize-AzOpsEnvironment` and `Remove-AzOpsDeployment` to leverage the new cmdlet
- Added integration test for resource deletion of `RoleAssignments` and `PolicyAssignments`