### PR TITLE
Added markdown linter exclusions

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -26,7 +26,10 @@ MD013:
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
+MD033:                        # Allow inline HTML
+  allowed_elements:
+    - br
+MD034: true                   # Allow bare urls
 MD036: false                  # Emphasis used instead of a heading
 
 #################


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Added some exclusions to `.markdown-lint.yml`

## This PR fixes/adds/changes/removes

1. Added `allowed_elements` to `MD033` to allow use of html tag <br/>
2. Added `MD034: true` to allow bare URLs. We need bare URLs to reference the AzOps-Accelerator repo in step-by-step guide.

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
