### PR TITLE
Expand Validate/WhatIf deployment error handling for WhatIf prediction failures

### DIFF
--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -130,7 +130,7 @@
                 else {
                     Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                     Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-                    Set-AzOpsWhatIfOutput -Results $results
+                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
                 }
 
                 $parameters.Name = $DeploymentName
@@ -181,7 +181,7 @@
                 else {
                     Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                     Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                    Set-AzOpsWhatIfOutput -Results $results
+                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
                 }
 
                 $parameters.Name = $DeploymentName
@@ -236,7 +236,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -Results $results
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
             }
 
             $parameters.Name = $DeploymentName
@@ -280,7 +280,7 @@
                 }
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -Results ('{0}TemplateFile: {2}{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage, $TemplateFilePath)
+                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results ('{0}TemplateFile: {2}{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage, $TemplateFilePath)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMe
@@ -294,7 +294,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -Results $results
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
             }
 
             $parameters.Name = $DeploymentName
@@ -339,7 +339,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -Results $results
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
             }
 
             $parameters.Name = $DeploymentName

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -280,7 +280,7 @@
                 }
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results ('{0}TemplateFile: {2}{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage, $TemplateFilePath)
+                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMe

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -280,7 +280,7 @@
                 }
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
+                    Set-AzOpsWhatIfOutput -Results ('{0}TemplateFile: {2}{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage, $TemplateFilePath)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMe

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -75,20 +75,20 @@
             if (($resultsError -ne $null) -or (-not $policyAssignment)) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemovePolicyAssignment.NoPolicyAssignmentFound' -StringValues $scopeObject.Scope, $resultsError -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName, $scopeObject.scope
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             elseif ((-not $roleAssignmentPermissionCheck)) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $contextObjectId, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName, $scopeObject.scope
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             else {
                 $results = '{0}: What if Successful: Performing the operation "Deleting the policy assignment..." on target {1}.' -f $deploymentName, $scopeObject.scope
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
             }
             #removal of resource
             if ($PSCmdlet.ShouldProcess("RemovePolicyAssignment?")) {
@@ -112,20 +112,20 @@
             if (($roleAssignmentError -ne $null) -or (-not $roleAssignment)) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveRoleAssignment.NoRoleAssignmentFound' -StringValues $scopeObject.Scope, $resultsError -Target $scopeObject
                 $results = '{0}: What if Failed: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName, $templateContent.resources[0].properties.PrincipalId, $roleAssignment.Scope, $templateContent.resources[0].properties.RoleDefinitionName
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             elseif (-not $roleAssignmentPermissionCheck) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext' -StringValues $contextObjectId, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Failed: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName, $templateContent.resources[0].properties.PrincipalId, $roleAssignment.Scope, $templateContent.resources[0].properties.RoleDefinitionName
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             else {
                 $results = '{0}: What if Successful: Performing the operation Removing role assignment for AD object {1} on scope {2} with role definition {3} on target {1}' -f $deploymentName, $templateContent.resources[0].properties.PrincipalId, $roleAssignment.Scope, $templateContent.resources[0].properties.RoleDefinitionName
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
             }
             #Remove of Resource
             if ($PSCmdlet.ShouldProcess("RemoveRoleAssignment?")) {

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -21,7 +21,10 @@
         $RemoveAzOpsFlag = $false,
 
         [Parameter(Mandatory = $false)]
-        $ResultSizeLimit = "64000"
+        $ResultSizeLimit = "64000",
+
+        [Parameter(Mandatory = $false)]
+        $TemplatePath
     )
 
     process {
@@ -40,10 +43,10 @@
             $resultString = $Results | Out-String
             $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
             if ($($resultStringMeasure.Characters) -gt $ResultSizeLimit) {
-                $mdOutput = 'WhatIf Results: WhatIf is too large for comment field, for more details look at PR files to determine changes.'
+                $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $TemplatePath
             }
             else {
-                $mdOutput = 'WhatIf Results: Resource Creation:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString
+                $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $TemplatePath
             }
             $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json)
             if ($existingContent.count -gt 0) {

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -34,9 +34,11 @@
             New-Item -Path '/tmp/OUTPUT.md' -WhatIf:$false
             New-Item -Path '/tmp/OUTPUT.json' -WhatIf:$false
         }
-
+        if ($TemplatePath -match '/') {
+            $TemplatePath = ($TemplatePath -split '/')[-1]
+        }
         if ($RemoveAzOpsFlag) {
-            $mdOutput = '{0}WhatIf Results: Resource Deletion:{1}{0}' -f [environment]::NewLine, $Results
+            $mdOutput = '{0}WhatIf Results for Resource Deletion of {2}:{0}```{0}{1}{0}```' -f [environment]::NewLine, $Results, $TemplatePath
         }
         else {
             $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -241,7 +241,7 @@
     'Remove-AzOpsDeployment.RemoveRoleAssignment.NoRoleAssignmentFound'             = 'Unable to find Role assignment with id {0} resulted in error {1}'# $roleAssignmentId,$resultsError
     'Remove-AzOpsDeployment.RemovePolicyAssignment.NoPolicyAssignmentFound'         = 'Unable to find Policy assignment with id {0} resulted in error {1}'# $policyAssignmentId,$resultsError
     'Remove-AzOpsDeployment.RemoveAssignment.MissingPermissionOnContext'            = 'This Context {0} dont have permission to remove on scope {1}'# $context.Account.id, $Id
-    'Remove-AzOpsDeployment.SkipUnsupportedResource'                                = 'Currently only Role Assignment and Policy Assignment resource deletion is supported. Hence, skiping any other Resouce deletion of file {0}'# $templateFilePath
+    'Remove-AzOpsDeployment.SkipUnsupportedResource'                                = 'Deletion is currently only supported for roleAssignment and policyAssignment resources. Will NOT proceed with deletion of file {0}'# $templateFilePath
 
     'Save-AzOpsManagementGroupChildren.Creating.Scope'                              = 'Creating scope object' #
     'Save-AzOpsManagementGroupChildren.Data.Directory'                              = 'Resolved state path directory: {0}' # $statepathDirectory


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Expand error handling for WhatIf prediction failures as per #545. 

## This PR fixes/adds/changes/removes

1. Expanded error handling for errors of type `DeploymentWhatIfResourceError`. 
2. Enriched/Contextualized WhatIf output with template file name to make it easier in case of multiple deployments in one PR


## Testing Evidence

Test deployments for the prediction failure scenario: 
![image](https://user-images.githubusercontent.com/16622613/151818819-f4506d0d-8561-4308-91e4-c499066870d5.png)
https://github.com/daltondhcp/azops-test00/pull/7

Test deployment for deletion with the enriched output: 
![image](https://user-images.githubusercontent.com/16622613/151819024-66c0b61c-8d14-486f-927a-f56e35ecd07d.png)
https://github.com/daltondhcp/azops-test00/pull/8


## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
