### PR TITLE
New-AzOpsScope Strings Update

### DIFF
--- a/src/internal/functions/New-AzOpsScope.ps1
+++ b/src/internal/functions/New-AzOpsScope.ps1
@@ -85,7 +85,7 @@
                 if (-not $Path.StartsWith($StatePathValidator)) {
                     Stop-PSFFunction -String 'New-AzOpsScope.Path.InvalidRoot' -StringValues $Path, $StatePath -EnableException $true -Cmdlet $PSCmdlet
                 }
-                Invoke-PSFProtectedCommand -ActionString 'New-AzOpsScope.Creating.FromFile' -Target $Path -ScriptBlock {
+                Invoke-PSFProtectedCommand -ActionString 'New-AzOpsScope.Creating.FromFile' -ActionStringValues $Path -Target $Path -ScriptBlock {
                     [AzOpsScope]::new($(Get-Item -Path $Path -Force), $StatePath)
                 } -EnableException $true -PSCmdlet $PSCmdlet
             }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -189,7 +189,7 @@
     'Invoke-AzOpsScriptBlock.Failed.GivingUp'                                       = 'Tried unsuccessfully {0} out of {1} times, giving up.' # $count, $RetryCount
     'Invoke-AzOpsScriptBlock.Failed.WillRetry'                                      = 'Tried unsuccessfully {0} out of {1} times, keeping up the fight!' # $count, $RetryCount
 
-    'New-AzOpsScope.Creating.FromFile'                                              = 'Creating a new scope from a path' #
+    'New-AzOpsScope.Creating.FromFile'                                              = 'Creating new scope from path {0}' # $Path
     'New-AzOpsScope.Creating.FromScope'                                             = 'Creating new AzOpsScope object using scope [{0}]' # $Scope
     'New-AzOpsScope.Creating.FromParentScope'                                       = 'Creating new AzOpsScope statepath using parent scope [{0}] with child resource details' # $Scope
     'New-AzOpsScope.Path.InvalidRoot'                                               = 'Path "{0}" must be a path under "{1}" !' # $Path, $StatePath


### PR DESCRIPTION
# Overview/Summary

Investigated issue #257  was not able to reproduce -WhatIf failure.

This PR updates the message output of 'New-AzOpsScope -Path' by adjusts the string message content of 'New-AzOpsScope.Creating.FromFile' and setting 'ActionStringValues' as the other actions in New-AzOpsScope function.

 Closing #257 with theses updated and harmonized message behaviors.

## This PR fixes/adds/changes/removes

1. Changes New-AzOpsScope -Path message output
2. Changes AzOpsScope.Creating.FromFile string composition

### Breaking Changes

N/A

## Testing Evidence

Tested to create new scope's with -Path with the new message output.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
