### PR TITLE
Bugfix in Get-AzOpsCurrentPrincipal to handle federated credentials

### DIFF
--- a/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
+++ b/src/internal/functions/Get-AzOpsCurrentPrincipal.ps1
@@ -28,7 +28,7 @@
                 $applicationId = (Invoke-RestMethod -Uri "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2021-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F" -Headers @{ Metadata = $true }).client_id
                 $principalObject = Get-AzADServicePrincipal -ApplicationId $applicationId
             }
-            'ServicePrincipal' {
+            default {
                 $principalObject = Get-AzADServicePrincipal -ApplicationId $AzContext.Account.Id
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Bugfix in Get-AzOpsCurrentPrincipal to enable lookup of federated credentials/AccountType `ClientAssertion` causing thed pipeline to fail.

### Breaking Changes

N/A

## Testing Evidence

**Before change:** 
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/16622613/156632786-c2e3db26-8884-4d54-8e89-4321f97eb300.png">

**After change:** 
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/16622613/156632849-75ee6739-8f3c-4c35-ae77-2d1d2ab8bb6d.png">

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
