### PR TITLE
Resolve "Initial Push pipeline run in ADO fail" with improved logic

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -279,8 +279,8 @@
         }
         $WhatIfPreference = $WhatIfPreferenceState
 
-        #If addModifySet exists and no deploymentList has been generated, exit with terminating error
-        if ($addModifySet -and -not $deploymentList) {
+        #If addModifySet exists and no deploymentList has been generated at the same time as the StatePath root has additional directories, exit with terminating error
+        if (($addModifySet -and -not $deploymentList) -and (Get-ChildItem -Path $StatePath -Directory)) {
             Write-PSFMessage -Level Critical @common -String 'Invoke-AzOpsPush.DeploymentList.NotFound'
             exit 1
         }


### PR DESCRIPTION
# Overview/Summary

Improved logic to allow a push to be run even when there is no deployment to be performed. This solves a particular situation which is connected to AzOps Accelerator usage with ADO.

This PR fixes #610 

## This PR fixes/adds/changes/removes

1. Changes logic in `Invoke-AzOpsPush.ps1`

### Breaking Changes

N/A

## Testing Evidence

Tests have been performed with and without a root state folder and with child directories to trigger behavior.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
