### PR TITLE
Set `main` as default branch in Azure DevOps

### DIFF
--- a/docs/wiki/Azure-Pipelines.md
+++ b/docs/wiki/Azure-Pipelines.md
@@ -84,6 +84,7 @@ if ($null -eq $Repo) {
 }
 az repos import create `
     --git-url "https://github.com/Azure/AzOps-Accelerator.git" --repository "$($Repo.name)"
+$null = az repos update --repository $RepoName --default-branch 'main'
 
 # Add a variable group for authenticating pipelines with Azure Resource Manager and record the id output
 if ($ARM_CLIENT_SECRET) {


### PR DESCRIPTION
# Overview/Summary

Add a line to the setup script for Azure Pipelines to set the `main` branch as default

## This PR fixes/adds/changes/removes

1. Setup script now sets main branch as default

## Testing Evidence

![image](https://user-images.githubusercontent.com/5576847/167351101-c7544f0d-6b74-4111-97cb-feee51b11b4b.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.

Closes #611 