### PR TITLE
Fix issue in `Get-AzManagementGroups` causing partial discovery to fail 🚑 🚑 🚑 

### DIFF
--- a/src/internal/functions/Get-AzOpsManagementGroups.ps1
+++ b/src/internal/functions/Get-AzOpsManagementGroups.ps1
@@ -45,7 +45,7 @@
                 $script:AzOpsPartialRoot += $groupObject
             }
             if ($groupObject.Children) {
-                $groupObject.Children | Where-Object Type -eq "/providers/Microsoft.Management/managementGroups" | Foreach-Object -Process {
+                $groupObject.Children | Where-Object Type -eq "Microsoft.Management/managementGroups" | Foreach-Object -Process {
                     Get-AzOpsManagementGroups -ManagementGroup $_.Name -PartialDiscovery:$PartialDiscovery
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update to `Get-AzOpsManagementGroups`  that fixes breaking change from Az.Resources 6.0.0 causing pipelines configured with `Core.PartialMgDiscoveryRoot` to fail. 

Closes #639 

### Breaking Changes

N/A

## Testing Evidence

✅ Validated [Pull](https://github.com/daltondhcp/azops-test00/actions/runs/2379856406), [Push](https://github.com/daltondhcp/azops-test00/actions/runs/2379925973) and [Validate](https://github.com/daltondhcp/azops-test00/actions/runs/2379895607) pipelines in environment that was previously failing 

**Output  Az.Resources < 6.0.0:**
![image](https://user-images.githubusercontent.com/16622613/170112071-57cddad2-680d-4ed1-b06b-adde2b0bcf04.png)

**Output after Az.Resources 6.0.0**
![image](https://user-images.githubusercontent.com/16622613/170111095-2f1d0b80-c4ba-414e-b22c-adf8f68005c3.png)


## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
