### PR TITLE
Adding Automated testing for Core.PartialMgDiscoveryRoot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ publish/*
 # Generated
 azops/*
 root/*
+partialmgdiscoveryroot/*
 
 # Debug
 **.private**

--- a/src/tests/functional/Functional.Tests.ps1
+++ b/src/tests/functional/Functional.Tests.ps1
@@ -9,11 +9,7 @@ $script:repositoryRoot = (Resolve-Path "$global:testroot/../..").Path
 $script:tenantId = $env:ARM_TENANT_ID
 $script:subscriptionId = $env:ARM_SUBSCRIPTION_ID
 
-#
-# Validate that the runtime variables
-# are set as they are used to authenticate
-# the Azure session.
-#
+# Validate that the runtime variables are set as they are used to authenticate the Azure session.
 
 if ($null -eq $script:tenantId) {
     Write-PSFMessage -Level Critical -Message "Unable to validate environment variable ARM_TENANT_ID"
@@ -24,11 +20,7 @@ if ($null -eq $script:subscriptionId) {
     throw
 }
 
-#
-# Ensure PowerShell has an authenticate
-# Azure Context which the tests can
-# run within and generate data as needed
-#
+# Ensure PowerShell has an authenticate Azure Context which the tests can run within and generate data as needed
 
 Write-PSFMessage -Level Verbose -Message "Validating Azure context" -FunctionName "BeforeAll"
 $tenant = (Get-AzContext -ListAvailable -ErrorAction SilentlyContinue).Tenant.Id
@@ -44,12 +36,7 @@ else {
     $null = Set-AzContext -TenantId $script:tenantId -SubscriptionId $script:subscriptionId
 }
 
-#
-# Deploy the Azure environment
-# based upon prefined resource templates
-# which will generate a matching
-# file system hierachy
-#
+# Deploy the Azure environment based upon prefined resource templates which will generate a matching file system hierachy
 
 Write-PSFMessage -Level Verbose -Message "Getting functional test objects based on structure" -FunctionName "BeforeAll"
 $script:functionalTestObjectPath = Join-Path $global:testroot -ChildPath "functional"
@@ -68,11 +55,7 @@ catch {
     Write-PSFMessage -Level Warning -String "Executing functional test object failed"
 }
 
-#
-# Ensure that the root directory
-# does not exist before running
-# tests.
-#
+# Ensure that the root directories does not exist before running tests.
 
 Write-PSFMessage -Level Verbose -Message "Testing for root directory existence" -FunctionName "BeforeAll"
 $generatedRoot = Join-Path -Path $script:repositoryRoot -ChildPath "root"
@@ -81,12 +64,7 @@ if (Test-Path -Path $generatedRoot) {
     Remove-Item -Path $generatedRoot -Recurse
 }
 
-#
-# Invoke the Invoke-AzOpsPull
-# function to generate the scope data which
-# can be tested against to ensure structure
-# is correct and data model hasn't changed.
-#
+# Invoke the Invoke-AzOpsPull function to generate the scope data which can be tested against to ensure structure is correct and data model hasn't changed.
 
 Set-PSFConfig -FullName AzOps.Core.SubscriptionsToIncludeResourceGroups -Value $script:subscriptionId
 Set-PSFConfig -FullName AzOps.Core.SkipChildResource -Value $false

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -131,7 +131,7 @@ Describe "Repository" {
         }
 
         # Invoke the Invoke-AzOpsPull function to generate the scope data which can be tested against to ensure structure is correct and data model hasn't changed.
-        
+
         #region PartialMgDiscoveryRoot Pull
         Set-PSFConfig -FullName AzOps.Core.PartialMgDiscoveryRoot -Value $($script:platformManagementGroup.Name)
         Set-PSFConfig -FullName AzOps.Core.State -Value $partialMgDiscoveryRootgeneratedRoot

--- a/src/tests/templates/azuredeploy.jsonc
+++ b/src/tests/templates/azuredeploy.jsonc
@@ -125,7 +125,7 @@
             ],
             "copy": {
                 "batchSize": 1,
-                "count": 25,
+                "count": 20,
                 "mode": "Serial",
                 "name": "waitingCompletion"
             },


### PR DESCRIPTION
# Overview/Summary

This PR extends the automated integration testing to include a situation where the `Core.PartialMgDiscoveryRoot` setting is configured, allowing us to avoid a similar situation as with release of 1.8.0 #639.

This closes #641 

## This PR fixes/adds/changes/removes

1.  changes integration test flow
2.  changes gitignore

### Breaking Changes

N/A

## Testing Evidence

Testing is automated and will be run as part of PR validation.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
