### PR TITLE
Set-AzOpsWhatIfOutput limit calc update

### DIFF
--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -145,7 +145,7 @@
                 # Handle WhatIf prediction errors
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
+                    Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
@@ -159,7 +159,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results
+                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results
             }
             # Remove ExcludeChangeType parameter as it doesn't exist for deployment cmdlets
             if ($parameters.ExcludeChangeType) {

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -86,10 +86,11 @@
 
         #region Process Scope
         # Configure variables/parameters and the WhatIf/Deployment cmdlets to be used per scope
+        $defaultDeploymentRegion = (Get-PSFConfigValue -FullName 'AzOps.Core.DefaultDeploymentRegion')
         $parameters = @{
             'TemplateFile'                = $TemplateFilePath
             'SkipTemplateParameterPrompt' = $true
-            'Location'                    = (Get-PSFConfigValue -FullName 'AzOps.Core.DefaultDeploymentRegion')
+            'Location'                    = $defaultDeploymentRegion
         }
         # Resource Groups excluding Microsoft.Resources/resourceGroups that needs to be submitted at subscription scope
         if ($scopeObject.resourcegroup -and $templateContent.resources[0].type -ne 'Microsoft.Resources/resourceGroups') {

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -145,7 +145,7 @@
                 # Handle WhatIf prediction errors
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
+                    Set-AzOpsWhatIfOutput -StatePath $scopeObject.StatePath -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
@@ -159,7 +159,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results
+                Set-AzOpsWhatIfOutput -StatePath $scopeObject.StatePath -Results $results
             }
             # Remove ExcludeChangeType parameter as it doesn't exist for deployment cmdlets
             if ($parameters.ExcludeChangeType) {

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -145,7 +145,7 @@
                 # Handle WhatIf prediction errors
                 elseif ($resultsErrorMessage -match 'DeploymentWhatIfResourceError' -and $resultsErrorMessage -match "The request to predict template deployment") {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
-                    Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
+                    Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results ('{0}WhatIf prediction failed with error - validate changes manually before merging:{0}{1}' -f [environment]::NewLine, $resultsErrorMessage)
                 }
                 else {
                     Write-PSFMessage -Level Warning -String 'New-AzOpsDeployment.WhatIfWarning' -Target $scopeObject -Tag Error -StringValues $resultsErrorMessage
@@ -159,7 +159,7 @@
             else {
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfResults' -StringValues ($results | Out-String) -Target $scopeObject
                 Write-PSFMessage -Level Verbose -String 'New-AzOpsDeployment.WhatIfFile' -Target $scopeObject
-                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results
+                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results
             }
             # Remove ExcludeChangeType parameter as it doesn't exist for deployment cmdlets
             if ($parameters.ExcludeChangeType) {

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -78,13 +78,13 @@
             if (-not $resourceToDelete) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.ResourceNotFound' -StringValues $scopeObject.Resource, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Deletion of target resource {1}. Resource could not be found' -f $removeJobName, $scopeObject.scope
-                Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results -RemoveAzOpsFlag $true
                 return
             }
             $results = '{0}: What if Successful: Performing the operation: Deletion of target resource {1}.' -f $removeJobName, $scopeObject.scope
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-            Set-AzOpsWhatIfOutput -TemplatePath $TemplateFilePath -Results $results -RemoveAzOpsFlag $true
+            Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results -RemoveAzOpsFlag $true
 
             if ($PSCmdlet.ShouldProcess("Remove $($scopeObject.Scope)?")) {
                 $null = Remove-AzResource -ResourceId $scopeObject.Scope -Force

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -78,13 +78,13 @@
             if (-not $resourceToDelete) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.ResourceNotFound' -StringValues $scopeObject.Resource, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Deletion of target resource {1}. Resource could not be found' -f $removeJobName, $scopeObject.scope
-                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -StatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             $results = '{0}: What if Successful: Performing the operation: Deletion of target resource {1}.' -f $removeJobName, $scopeObject.scope
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-            Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
+            Set-AzOpsWhatIfOutput -StatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
 
             if ($PSCmdlet.ShouldProcess("Remove $($scopeObject.Scope)?")) {
                 $null = Remove-AzResource -ResourceId $scopeObject.Scope -Force

--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -78,13 +78,13 @@
             if (-not $resourceToDelete) {
                 Write-PSFMessage -Level Warning -String 'Remove-AzOpsDeployment.ResourceNotFound' -StringValues $scopeObject.Resource, $scopeObject.Scope -Target $scopeObject
                 $results = '{0}: What if Operation Failed: Deletion of target resource {1}. Resource could not be found' -f $removeJobName, $scopeObject.scope
-                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results -RemoveAzOpsFlag $true
+                Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
                 return
             }
             $results = '{0}: What if Successful: Performing the operation: Deletion of target resource {1}.' -f $removeJobName, $scopeObject.scope
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $results -Target $scopeObject
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile' -Target $scopeObject
-            Set-AzOpsWhatIfOutput -TemplatePath $scopeObject -Results $results -RemoveAzOpsFlag $true
+            Set-AzOpsWhatIfOutput -TemplatePath $scopeObject.StatePath -Results $results -RemoveAzOpsFlag $true
 
             if ($PSCmdlet.ShouldProcess("Remove $($scopeObject.Scope)?")) {
                 $null = Remove-AzResource -ResourceId $scopeObject.Scope -Force

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -5,11 +5,19 @@
             Logs the output from a What-If deployment
         .DESCRIPTION
             Logs the output from a What-If deployment
-        .PARAMETER results
+        .PARAMETER Results
             The WhatIf result from a deployment
+        .PARAMETER RemoveAzOpsFlag
+            RemoveAzOpsFlag is set to true when a need to push content about deletion is required
+        .PARAMETER ResultSizeLimit
+            The character limit allowed for comments 64,000
+        .PARAMETER ResultSizeMaxLimit
+            The maximum upper character limit allowed for comments 64,600
+        .PARAMETER TemplatePath
+            Associated Template file
         .EXAMPLE
-            > Set-AzOpsWhatIfOutput -results $results -removeAzOpsFlag $true
-            $removeAzOpsFlag is set to true when we need to push contents for Remove-AzopsDeployment to PR
+            > Set-AzOpsWhatIfOutput -Results $results
+            > Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
     #>
 
     [CmdletBinding()]
@@ -24,11 +32,16 @@
         $ResultSizeLimit = "64000",
 
         [Parameter(Mandatory = $false)]
+        $ResultSizeMaxLimit = "64600",
+
+        [Parameter(Mandatory = $false)]
         $TemplatePath
     )
 
     process {
         Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile'
+
+        $WhatIfIsLargeMsg = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.'
 
         if (-not (Test-Path -Path '/tmp/OUTPUT.md')) {
             New-Item -Path '/tmp/OUTPUT.md' -WhatIf:$false
@@ -37,29 +50,43 @@
         if ($TemplatePath -match '/') {
             $TemplatePath = ($TemplatePath -split '/')[-1]
         }
-        if ($RemoveAzOpsFlag) {
-            $mdOutput = '{0}WhatIf Results for Resource Deletion of {2}:{0}```{0}{1}{0}```' -f [environment]::NewLine, $Results, $TemplatePath
+        # Measure input $Results.Changes content
+        $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)
+        $resultString = $Results | Out-String
+        $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
+        Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $Results
+        # Measure current /tmp/OUTPUT.md content
+        $existingContentMd = Get-Content -Path '/tmp/OUTPUT.md' -Raw
+        $existingContentStringMd = $existingContentMd | Out-String
+        $existingContentStringMeasureMd = $existingContentStringMd | Measure-Object -Line -Character -Word
+        # Gather current /tmp/OUTPUT.json content
+        $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json -Depth 100)
+        # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
+        if (($($existingContentStringMeasureMd.Characters) + $($resultStringMeasure.Characters)) -gt $ResultSizeLimit) {
+            $mdOutput = $WhatIfIsLargeMsg -f [environment]::NewLine, $TemplatePath
         }
         else {
-            $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)
-            $resultString = $Results | Out-String
-            $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
-            if ($($resultStringMeasure.Characters) -gt $ResultSizeLimit) {
-                $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $TemplatePath
+            if ($RemoveAzOpsFlag) {
+                $mdOutput = '{0}WhatIf Results for Resource Deletion of {2}:{0}```{0}{1}{0}```' -f [environment]::NewLine, $Results, $TemplatePath
             }
             else {
+                if ($existingContent.count -gt 0) {
+                    $existingContent += $results.Changes
+                    $existingContent = $existingContent | ConvertTo-Json -Depth 100
+                }
+                else {
+                    $existingContent = $resultJson
+                }
                 $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $TemplatePath
             }
-            $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json)
-            if ($existingContent.count -gt 0) {
-                $existingContent += $results.Changes
-                $existingContent = $existingContent | ConvertTo-Json -Depth 100
-            }
-            else {
-                $existingContent = $resultJson
-            }
+        }
+        if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $($existingContentStringMeasureMd.Characters)) -le $ResultSizeMaxLimit) {
+            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAdding'
+            Add-Content -Path '/tmp/OUTPUT.md' -Value $mdOutput -WhatIf:$false
             Set-Content -Path '/tmp/OUTPUT.json' -Value $existingContent -WhatIf:$false
         }
-        Add-Content -Path '/tmp/OUTPUT.md' -Value $mdOutput -WhatIf:$false
+        else {
+            Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeMaxLimit
+        }
     }
 }

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -58,7 +58,7 @@
         # Gather current /tmp/OUTPUT.json content
         $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json -Depth 100)
         # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
-        if (($($existingContentStringMeasureMd.Characters) + $($resultStringMeasure.Characters)) -gt $ResultSizeLimit) {
+        if (($existingContentStringMeasureMd.Characters + $resultStringMeasure.Characters) -gt $ResultSizeLimit) {
             Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeLimit
             $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $StatePath
         }
@@ -79,7 +79,7 @@
                 Set-Content -Path '/tmp/OUTPUT.json' -Value $existingContent -WhatIf:$false
             }
         }
-        if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $($existingContentStringMeasureMd.Characters)) -le $ResultSizeMaxLimit) {
+        if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $existingContentStringMeasureMd.Characters) -le $ResultSizeMaxLimit) {
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'
             Add-Content -Path '/tmp/OUTPUT.md' -Value $mdOutput -WhatIf:$false
         }

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -13,8 +13,8 @@
             The character limit allowed for comments 64,000
         .PARAMETER ResultSizeMaxLimit
             The maximum upper character limit allowed for comments 64,600
-        .PARAMETER TemplatePath
-            Associated Template file
+        .PARAMETER StatePath
+            File in scope of WhatIf
         .EXAMPLE
             > Set-AzOpsWhatIfOutput -Results $results
             > Set-AzOpsWhatIfOutput -Results $results -RemoveAzOpsFlag $true
@@ -35,7 +35,7 @@
         $ResultSizeMaxLimit = "64600",
 
         [Parameter(Mandatory = $false)]
-        $TemplatePath
+        $StatePath
     )
 
     process {
@@ -44,8 +44,8 @@
             New-Item -Path '/tmp/OUTPUT.md' -WhatIf:$false
             New-Item -Path '/tmp/OUTPUT.json' -WhatIf:$false
         }
-        if ($TemplatePath -match '/') {
-            $TemplatePath = ($TemplatePath -split '/')[-1]
+        if ($StatePath -match '/') {
+            $StatePath = ($StatePath -split '/')[-1]
         }
         # Measure input $Results.Changes content
         $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)
@@ -60,11 +60,11 @@
         # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
         if (($($existingContentStringMeasureMd.Characters) + $($resultStringMeasure.Characters)) -gt $ResultSizeLimit) {
             Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeLimit
-            $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $TemplatePath
+            $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $StatePath
         }
         else {
             if ($RemoveAzOpsFlag) {
-                $mdOutput = '{0}WhatIf Results for Resource Deletion of {2}:{0}```{0}{1}{0}```' -f [environment]::NewLine, $Results, $TemplatePath
+                $mdOutput = '{0}WhatIf Results for Resource Deletion of {2}:{0}```{0}{1}{0}```' -f [environment]::NewLine, $Results, $StatePath
             }
             else {
                 if ($existingContent.count -gt 0) {
@@ -74,7 +74,7 @@
                 else {
                     $existingContent = $resultJson
                 }
-                $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $TemplatePath
+                $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $StatePath
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'
                 Set-Content -Path '/tmp/OUTPUT.json' -Value $existingContent -WhatIf:$false
             }

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -40,9 +40,6 @@
 
     process {
         Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile'
-
-        $WhatIfIsLargeMsg = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.'
-
         if (-not (Test-Path -Path '/tmp/OUTPUT.md')) {
             New-Item -Path '/tmp/OUTPUT.md' -WhatIf:$false
             New-Item -Path '/tmp/OUTPUT.json' -WhatIf:$false
@@ -54,7 +51,6 @@
         $resultJson = ($Results.Changes | ConvertTo-Json -Depth 100)
         $resultString = $Results | Out-String
         $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
-        Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfResults' -StringValues $Results
         # Measure current /tmp/OUTPUT.md content
         $existingContentMd = Get-Content -Path '/tmp/OUTPUT.md' -Raw
         $existingContentStringMd = $existingContentMd | Out-String
@@ -63,7 +59,7 @@
         $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json -Depth 100)
         # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
         if (($($existingContentStringMeasureMd.Characters) + $($resultStringMeasure.Characters)) -gt $ResultSizeLimit) {
-            $mdOutput = $WhatIfIsLargeMsg -f [environment]::NewLine, $TemplatePath
+            $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $TemplatePath
         }
         else {
             if ($RemoveAzOpsFlag) {

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -74,12 +74,13 @@
                     $existingContent = $resultJson
                 }
                 $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $TemplatePath
+                Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'
+                Set-Content -Path '/tmp/OUTPUT.json' -Value $existingContent -WhatIf:$false
             }
         }
         if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $($existingContentStringMeasureMd.Characters)) -le $ResultSizeMaxLimit) {
-            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAdding'
+            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'
             Add-Content -Path '/tmp/OUTPUT.md' -Value $mdOutput -WhatIf:$false
-            Set-Content -Path '/tmp/OUTPUT.json' -Value $existingContent -WhatIf:$false
         }
         else {
             Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeMaxLimit

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -59,6 +59,7 @@
         $existingContent = @(Get-Content -Path '/tmp/OUTPUT.json' -Raw | ConvertFrom-Json -Depth 100)
         # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
         if (($($existingContentStringMeasureMd.Characters) + $($resultStringMeasure.Characters)) -gt $ResultSizeLimit) {
+            Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeLimit
             $mdOutput = 'WhatIf Results for {1}:{0} WhatIf is too large for comment field, for more details look at PR files to determine changes.' -f [environment]::NewLine, $TemplatePath
         }
         else {

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -84,7 +84,7 @@
             Add-Content -Path '/tmp/OUTPUT.md' -Value $mdOutput -WhatIf:$false
         }
         else {
-            Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeMaxLimit
+            Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfMessageMax' -StringValues $ResultSizeMaxLimit
         }
     }
 }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -272,5 +272,7 @@
     'Set-AzOpsStringLength.WithInLimit'                                             = 'String {0} within limit of {1}' # $String
 
     'Set-AzOpsWhatIfOutput.WhatIfFile'                                              = 'Creating WhatIf markdown and json files' #
-    'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}'
+    'Set-AzOpsWhatIfOutput.WhatIfFileAdding'                                        = 'Adding content to WhatIf markdown and json files' #
+    'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached maximum character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit
+    'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}' # $results
 }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -274,6 +274,7 @@
     'Set-AzOpsWhatIfOutput.WhatIfFile'                                              = 'Creating WhatIf markdown and json files' #
     'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'                                    = 'Adding content to WhatIf json file' #
     'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'                                      = 'Adding content to WhatIf markdown file' #
-    'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached maximum character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
+    'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
+    'Set-AzOpsWhatIfOutput.WhatIfMessageMax'                                        = 'WhatIf have reached maximum character limit, unable to append warning message. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
     'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}' # $results
 }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -274,6 +274,6 @@
     'Set-AzOpsWhatIfOutput.WhatIfFile'                                              = 'Creating WhatIf markdown and json files' #
     'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'                                    = 'Adding content to WhatIf json file' #
     'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'                                      = 'Adding content to WhatIf markdown file' #
-    'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached maximum character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit
+    'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached maximum character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
     'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}' # $results
 }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -272,7 +272,8 @@
     'Set-AzOpsStringLength.WithInLimit'                                             = 'String {0} within limit of {1}' # $String
 
     'Set-AzOpsWhatIfOutput.WhatIfFile'                                              = 'Creating WhatIf markdown and json files' #
-    'Set-AzOpsWhatIfOutput.WhatIfFileAdding'                                        = 'Adding content to WhatIf markdown and json files' #
+    'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'                                    = 'Adding content to WhatIf json file' #
+    'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'                                      = 'Adding content to WhatIf markdown file' #
     'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached maximum character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit
     'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}' # $results
 }

--- a/src/tests/functional/Microsoft.Authorization/policyAssignments/scenario.ps1
+++ b/src/tests/functional/Microsoft.Authorization/policyAssignments/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - policyAssignments" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Authorization/roleAssignments/scenario.ps1
+++ b/src/tests/functional/Microsoft.Authorization/roleAssignments/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - roleAssignments" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Authorization/roleEligibilityScheduleRequests/scenario.ps1
+++ b/src/tests/functional/Microsoft.Authorization/roleEligibilityScheduleRequests/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - roleEligibilityScheduleRequests" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.KeyVault/vaults/scenario.ps1
+++ b/src/tests/functional/Microsoft.KeyVault/vaults/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - vaults" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Management/managementGroups/scenario.ps1
+++ b/src/tests/functional/Microsoft.Management/managementGroups/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - managementGroups" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/azureFirewalls/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/azureFirewalls/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - azureFirewalls" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/networkInterfaces/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/networkInterfaces/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - networkInterfaces" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/networkSecurityGroups/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/networkSecurityGroups/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - networkSecurityGroups" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/publicIPAddresses/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/publicIPAddresses/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - publicIPAddresses" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/routeTables/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/routeTables/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - routeTables" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Network/virtualNetworks/scenario.ps1
+++ b/src/tests/functional/Microsoft.Network/virtualNetworks/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - virtualNetworks" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "BeforeAll"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "BeforeAll"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Resources/resourceGroups/scenario.ps1
+++ b/src/tests/functional/Microsoft.Resources/resourceGroups/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - resourceGroups" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Storage/storageAccounts/scenario.ps1
+++ b/src/tests/functional/Microsoft.Storage/storageAccounts/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - storageAccounts" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Web/serverfarms/scenario.ps1
+++ b/src/tests/functional/Microsoft.Web/serverfarms/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - serverfarms" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer

--- a/src/tests/functional/Microsoft.Web/sites/scenario.ps1
+++ b/src/tests/functional/Microsoft.Web/sites/scenario.ps1
@@ -19,7 +19,7 @@ Describe "Scenario - sites" {
         $script:directory = ($script:path).Directory
         $script:file = ($script:path).FullName
         $script:fileContents = Get-Content -Path $script:file -Raw | ConvertFrom-Json -Depth 25
-        Write-PSFMessage -Level Debug -Message "TestResoucePath: $($script:file)" -FunctionName "Functional Tests"
+        Write-PSFMessage -Level Debug -Message "TestResourcePath: $($script:file)" -FunctionName "Functional Tests"
         #endregion Paths
 
         #region Push Primer


### PR DESCRIPTION
# Overview/Summary

This PR fixes #652 
As the issue describes current character limit does not correctly take into account all character aspects.
Logic is updated to take existing content into account and also produce warnings at runtime when maximum is reached.

## This PR fixes/adds/changes/removes

1. Fixes Set-AzOpsWhatIfOutput.ps1
2. Changes New-AzOpsDeployment.ps1
3. Changes Remove-AzOpsDeployment.ps1
4. Changes Strings.psd1

### Breaking Changes

N/A

## Testing Evidence
Entire PR within limits:
![image](https://user-images.githubusercontent.com/64077181/176653403-67d7cb22-de15-4c8a-9ee7-1b0dcb37cf7d.png)
Parts of PR within limits:
![image](https://user-images.githubusercontent.com/64077181/176653898-2a6ee6bc-fe2a-4b59-8afe-74d176d4bed2.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
