### PR TITLE
Generalize Temp Pathing

### DIFF
--- a/src/internal/functions/Get-AzOpsResourceDefinition.ps1
+++ b/src/internal/functions/Get-AzOpsResourceDefinition.ps1
@@ -397,7 +397,7 @@
                                 if (-not $resources) {
                                     Write-PSFMessage -Level Verbose @msgCommon -String 'Get-AzOpsResourceDefinition.SubScription.Processing.ResourceGroup.NoResources' -StringValues $resourceGroup.ResourceGroupName -Target $resourceGroup
                                 }
-                                $tempExportPath = "/tmp/" + $resourceGroup.ResourceGroupName + ".json"
+                                $tempExportPath = [System.IO.Path]::GetTempPath() + $resourceGroup.ResourceGroupName + ".json"
                                 # Loop through resources and convert them to AzOpsState
                                 foreach ($resource in $resources) {
                                     # Convert resources to AzOpsState

--- a/src/internal/functions/Get-AzOpsResourceDefinition.ps1
+++ b/src/internal/functions/Get-AzOpsResourceDefinition.ps1
@@ -397,7 +397,7 @@
                                 if (-not $resources) {
                                     Write-PSFMessage -Level Verbose @msgCommon -String 'Get-AzOpsResourceDefinition.SubScription.Processing.ResourceGroup.NoResources' -StringValues $resourceGroup.ResourceGroupName -Target $resourceGroup
                                 }
-                                $tempExportPath = [System.IO.Path]::GetTempPath() + $resourceGroup.ResourceGroupName + ".json"
+                                $tempExportPath = [System.IO.Path]::GetTempPath() + $resourceGroup.ResourceGroupName + '.json'
                                 # Loop through resources and convert them to AzOpsState
                                 foreach ($resource in $resources) {
                                     # Convert resources to AzOpsState

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -77,7 +77,7 @@
                 }
                 $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $StatePath
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'
-                Set-Content -Path ($tempPath + 'UTPUT.json') -Value $existingContent -WhatIf:$false
+                Set-Content -Path ($tempPath + 'OUTPUT.json') -Value $existingContent -WhatIf:$false
             }
         }
         if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $existingContentStringMeasureMd.Characters) -le $ResultSizeMaxLimit) {

--- a/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
+++ b/src/internal/functions/Set-AzOpsWhatIfOutput.ps1
@@ -41,9 +41,9 @@
     process {
         Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile'
         $tempPath = [System.IO.Path]::GetTempPath()
-        if (-not (Test-Path -Path ($tempPath + "OUTPUT.md"))) {
-            New-Item -Path ($tempPath + "OUTPUT.md") -WhatIf:$false
-            New-Item -Path ($tempPath + "OUTPUT.json") -WhatIf:$false
+        if (-not (Test-Path -Path ($tempPath + 'OUTPUT.md'))) {
+            New-Item -Path ($tempPath + 'OUTPUT.md') -WhatIf:$false
+            New-Item -Path ($tempPath + 'OUTPUT.json') -WhatIf:$false
         }
         if ($StatePath -match '/') {
             $StatePath = ($StatePath -split '/')[-1]
@@ -53,11 +53,11 @@
         $resultString = $Results | Out-String
         $resultStringMeasure = $resultString | Measure-Object -Line -Character -Word
         # Measure current OUTPUT.md content
-        $existingContentMd = Get-Content -Path ($tempPath + "OUTPUT.md") -Raw
+        $existingContentMd = Get-Content -Path ($tempPath + 'OUTPUT.md') -Raw
         $existingContentStringMd = $existingContentMd | Out-String
         $existingContentStringMeasureMd = $existingContentStringMd | Measure-Object -Line -Character -Word
         # Gather current OUTPUT.json content
-        $existingContent = @(Get-Content -Path ($tempPath + "OUTPUT.json") -Raw | ConvertFrom-Json -Depth 100)
+        $existingContent = @(Get-Content -Path ($tempPath + 'OUTPUT.json') -Raw | ConvertFrom-Json -Depth 100)
         # Check if $existingContentStringMeasureMd and $resultStringMeasure exceed allowed size in $ResultSizeLimit
         if (($existingContentStringMeasureMd.Characters + $resultStringMeasure.Characters) -gt $ResultSizeLimit) {
             Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfFileMax' -StringValues $ResultSizeLimit
@@ -77,12 +77,12 @@
                 }
                 $mdOutput = 'WhatIf Results for {2}:{0}```{0}{1}{0}```{0}' -f [environment]::NewLine, $resultString, $StatePath
                 Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingJson'
-                Set-Content -Path ($tempPath + "OUTPUT.json") -Value $existingContent -WhatIf:$false
+                Set-Content -Path ($tempPath + 'UTPUT.json') -Value $existingContent -WhatIf:$false
             }
         }
         if ((($mdOutput | Measure-Object -Line -Character -Word).Characters + $existingContentStringMeasureMd.Characters) -le $ResultSizeMaxLimit) {
             Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFileAddingMd'
-            Add-Content -Path ($tempPath + "OUTPUT.md") -Value $mdOutput -WhatIf:$false
+            Add-Content -Path ($tempPath + 'OUTPUT.md') -Value $mdOutput -WhatIf:$false
         }
         else {
             Write-PSFMessage -Level Warning -String 'Set-AzOpsWhatIfOutput.WhatIfMessageMax' -StringValues $ResultSizeMaxLimit

--- a/src/tests/functional/Microsoft.Insights/activityLogAlerts/deploy/deploy.json
+++ b/src/tests/functional/Microsoft.Insights/activityLogAlerts/deploy/deploy.json
@@ -77,7 +77,8 @@
             "name": "[parameters('alertName')]",
             "type": "Microsoft.Insights/ActivityLogAlerts",
             "location": "[parameters('location')]",
-            "apiVersion": "2017-04-01",
+            "dependsOn": ["[resourceId('microsoft.insights/actionGroups',parameters('actionGroupName'))]"],
+            "apiVersion": "2020-10-01",
             "properties": {
                 "scopes": "[parameters('scopes')]",
                 "condition": {

--- a/src/tests/templates/azuredeploy.jsonc
+++ b/src/tests/templates/azuredeploy.jsonc
@@ -125,7 +125,7 @@
             ],
             "copy": {
                 "batchSize": 1,
-                "count": 20,
+                "count": 25,
                 "mode": "Serial",
                 "name": "waitingCompletion"
             },


### PR DESCRIPTION
# Overview/Summary

Harmonize temporary files output location by querying runtime environment for location.

Closes #678

## This PR fixes/adds/changes/removes

1. Adjust Get-AzOpsResourceDefinition.ps1 temporary export path
2. Adjust Set-AzOpsWhatIfOutput.ps1 export path

### Breaking Changes

1. N/A

## Testing Evidence

Testing has been performed on Linux and Windows runtime environment without errors.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
