### PR TITLE
Ensure management group name uniqueness

### DIFF
--- a/src/AzOps.psd1
+++ b/src/AzOps.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '7.2'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'PSFramework'; RequiredVersion = '1.7.237'; }, 
+RequiredModules = @(@{ModuleName = 'PSFramework'; RequiredVersion = '1.7.244'; }, 
                @{ModuleName = 'Az.Accounts'; RequiredVersion = '2.9.1'; }, 
                @{ModuleName = 'Az.Billing'; RequiredVersion = '2.0.0'; }, 
                @{ModuleName = 'Az.Resources'; RequiredVersion = '6.1.0'; })

--- a/src/internal/classes/AzOpsScope.ps1
+++ b/src/internal/classes/AzOpsScope.ps1
@@ -412,7 +412,7 @@
 
         if ($this.GetManagementGroupName()) {
             foreach ($mgmt in $script:AzOpsAzManagementGroup) {
-                if ($mgmt.DisplayName -eq $this.GetManagementGroupName()) {
+                if ($mgmt.Name -eq $this.GetManagementGroupName()) {
                     return $mgmt.Name
                 }
             }
@@ -457,7 +457,7 @@
             $mgId = $this.Scope -split $this.regex_managementgroupExtract -split '/' | Where-Object { $_ } | Select-Object -First 1
 
             if ($mgId) {
-                $mgDisplayName = ($script:AzOpsAzManagementGroup | Where-Object Name -eq $mgId).DisplayName
+                $mgDisplayName = ($script:AzOpsAzManagementGroup | Where-Object Name -eq $mgId).Name
                 if ($mgDisplayName) {
                     #Write-PSFMessage -Level Debug -String 'AzOpsScope.GetManagementGroupName.Found.Azure' -StringValues $mgDisplayName -FunctionName AzOpsScope -ModuleName AzOps
                     return $mgDisplayName
@@ -472,7 +472,7 @@
             foreach ($managementGroup in $script:AzOpsAzManagementGroup) {
                 foreach ($child in $managementGroup.Children) {
                     if ($child.Type -eq '/subscriptions' -and $child.DisplayName -eq $this.subscriptionDisplayName) {
-                        return $managementGroup.DisplayName
+                        return $managementGroup.Name
                     }
                 }
             }

--- a/src/tests/templates/azuredeploy.jsonc
+++ b/src/tests/templates/azuredeploy.jsonc
@@ -125,7 +125,7 @@
             ],
             "copy": {
                 "batchSize": 1,
-                "count": 25,
+                "count": 30,
                 "mode": "Serial",
                 "name": "waitingCompletion"
             },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

- Fix issue where management groups with the same displayName didn't pull successfully. 
Removed all references to displayName in logic. 

- Bump PSFramework version 
### Breaking Changes

N/A

## Testing Evidence

Verified in environment that previously failed. Tests should ensure no new issues have been introduced with these changes. 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
