### PR TITLE
Added graceful error handling for child resource export

### DIFF
--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -99,6 +99,7 @@
     'Get-AzOpsPolicySetDefinition.ManagementGroup'                                  = 'Retrieving PolicySet Definition for ManagementGroup {0} ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
     'Get-AzOpsPolicySetDefinition.Subscription'                                     = 'Retrieving PolicySet Definition for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
 
+    'Get-AzOpsResourceDefinition.ChildResource.Warning'                             = 'Failed to export childResources in [{0}]. Warning: [{1}]' # $resourceGroup.ResourceGroupName, $_
     'Get-AzOpsResourceDefinition.Finished'                                          = 'Finished processing scope [{0}]' # $scopeObject.Scope
     'Get-AzOpsResourceDefinition.ManagementGroup.Processing'                        = 'Processing Management Group [{0}] ({1})' # $ScopeObject.ManagementGroupDisplayName, $ScopeObject.ManagementGroup
     'Get-AzOpsResourceDefinition.ManagementGroup.Subscription.NotFound'             = 'Unable to locate subscription: {0} within AzOpsSubscriptions object' #child.Name


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Partially adressing #699, specifically the RP-errors from the export API. 
![image](https://user-images.githubusercontent.com/16622613/201990068-0623bbba-d9f8-4bfa-b274-d25291c03ac4.png)

## Testing Evidence

Tested in my own demo environment successfuly. 
Test coverage for the scenarios in place. In case the specific child resources in the test cases are not exported due to RP issues, tests will obviously fail ❌ 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X} Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
