### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   dependencies:
     name: "Automated Dependencies"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Configure"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     name: "Release"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Configure"
         run: |

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Checkout
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   tests:
     name: "Tests"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: test
     env:
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.wiki_source_repo }}
           path: ${{ env.wiki_source_repo }}
 
       - name: Checkout Wiki Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.wiki_target_repo }}
           path: ${{ env.wiki_target_repo }}

--- a/docs/wiki/Self-Hosted.md
+++ b/docs/wiki/Self-Hosted.md
@@ -19,7 +19,7 @@ Virtual Machine Scale Sets are optimal for hosting your self-hosted agents/runne
 
 ## Image
 
-To setup a VMSS for your self-hosted agents/runners you need an image with all the required software installed. The pipelines and actions provided in the [AzOps-Accelerator](https://github.com/Azure/AzOps-Accelerator) repository are using the GitHub Actions Virtual Environments [`ubuntu-20.04`](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md) image by default. The images includes multiple tools and software including all AzOps requirements.
+To setup a VMSS for your self-hosted agents/runners you need an image with all the required software installed. The pipelines and actions provided in the [AzOps-Accelerator](https://github.com/Azure/AzOps-Accelerator) repository are using the GitHub Actions Virtual Environments [`ubuntu-latest`](https://github.com/actions/runner-images/tree/main/images/linux) image by default. The images includes multiple tools and software including all AzOps requirements.
 
 ### Build an image using GitHub Actions Virtual Environments
 


### PR DESCRIPTION
# Overview/Summary

This PR updates dependant checkout action from v2 to v3 to keep with the times [Node 12 out of support](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

## This PR fixes/adds/changes/removes

1. Changes all workflows to `actions/checkout@v3` from `actions/checkout@v2`

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
