### PR TITLE
Update to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           ./scripts/Version.ps1 -Type ${{ github.event.inputs.type }}
           $Version = (Import-PowerShellDataFile -Path "./src/AzOps.psd1").ModuleVersion
-          Write-Host "::set-output name=version::$Version"
+          $GITHUB_OUTPUT = "version=$Version"
+          Write-Host $GITHUB_OUTPUT
         shell: pwsh
 
       - name: "Release"


### PR DESCRIPTION
# Overview/Summary

Update GitHub Action `release` step Version from `set-output` to new `$GITHUB_OUTPUT`.

[Deprecating set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## This PR fixes/adds/changes/removes

1. changes `release.yml`

### Breaking Changes

N/A

## Testing Evidence

Tested logic update in simple action and output remains.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
