### PR TITLE
Add support for wildcard in setting Azops.Core.IncludeResourcesInResourceGroup

### DIFF
--- a/src/internal/functions/Get-AzOpsResourceDefinition.ps1
+++ b/src/internal/functions/Get-AzOpsResourceDefinition.ps1
@@ -165,15 +165,9 @@
                 Write-PSFMessage -Level Verbose @common -String 'Get-AzOpsResourceDefinition.ResourceGroup.Processing' -StringValues $ScopeObject.Resourcegroup, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
 
                 try {
-                    if ($IncludeResourcesInResourceGroup -eq "*") {
+                    if (($IncludeResourcesInResourceGroup | Foreach-Object { $ScopeObject.ResourceGroup -like $_ }) -contains $true) {
                         Write-PSFMessage -Level Verbose @common -String 'Get-AzOpsResourceDefinition.ResourceGroup.Processing' -StringValues $resourceGroup.ResourceGroupName, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
                         $resourceGroup = Get-AzResourceGroup -Name $ScopeObject.ResourceGroup -DefaultProfile $Context -ErrorAction Stop
-                    }
-                    else {
-                        if ($ScopeObject.ResourceGroup -in $IncludeResourcesInResourceGroup) {
-                            Write-PSFMessage -Level Verbose @common -String 'Get-AzOpsResourceDefinition.ResourceGroup.Processing' -StringValues $resourceGroup.ResourceGroupName, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
-                            $resourceGroup = Get-AzResourceGroup -Name $ScopeObject.ResourceGroup -DefaultProfile $Context -ErrorAction Stop
-                        }
                     }
                 }
                 catch {
@@ -372,11 +366,9 @@
 
                             if (-not $using:SkipResource) {
                                 Write-PSFMessage -Level Verbose @msgCommon -String 'Get-AzOpsResourceDefinition.SubScription.Processing.ResourceGroup.Resources' -StringValues $resourceGroup.ResourceGroupName -Target $resourceGroup
-                                if ($runspaceData.IncludeResourcesInResourceGroup -ne "*") {
-                                    if ($resourceGroup.ResourceGroupName -notin $runspaceData.IncludeResourcesInResourceGroup) {
-                                        Write-PSFMessage -Level Verbose @msgCommon -String 'Get-AzOpsResourceDefinition.Subscription.Processing.IncludeResourcesInRG' -StringValues $resourceGroup.ResourceGroupName -Target $resourceGroup
-                                        continue
-                                    }
+                                if (($runspaceData.IncludeResourcesInResourceGroup | Foreach-Object { $resourceGroup.ResourceGroupName -like $_ }) -notcontains $true) {
+                                    Write-PSFMessage -Level Verbose @msgCommon -String 'Get-AzOpsResourceDefinition.Subscription.Processing.IncludeResourcesInRG' -StringValues $resourceGroup.ResourceGroupName -Target $resourceGroup
+                                    continue
                                 }
                                 try {
                                     $resources = & $azOps {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This PR closes #697 by adding support for wildcard in setting `Azops.Core.IncludeResourcesInResourceGroup`.

## This PR fixes/adds/changes/removes

1. Changes `Get-AzOpsResourceDefinition.ps1`

### Breaking Changes

1. n/a

## Testing Evidence

Tested in my own environment with 100+ subscriptions using wildcard like `*` and `rg-name-*`.

Also tried the pester tests, but a bit unsure if we should add anything there or not for this setting. The docs/wiki might still be good as is. 

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
