### PR TITLE
Remove `Directory Readers` Azure AD role requirement for `roleAssignments` pull 

### DIFF
--- a/docs/wiki/Prerequisites.md
+++ b/docs/wiki/Prerequisites.md
@@ -34,7 +34,7 @@ Install-Module Az.Accounts, Az.Resources
 # Connect to Azure
 Connect-AzAccount
 
-# Create Service Principal 
+# Create Service Principal
 $servicePrincipalDisplayName = "<name of service principal>"
 $servicePrincipal = New-AzADServicePrincipal -DisplayName $servicePrincipalDisplayName
 
@@ -67,7 +67,7 @@ $servicePrincipal = Get-AzADServicePrincipal -DisplayName $servicePrincipalDispl
 New-AzRoleAssignment -ObjectId $servicePrincipal.Id -RoleDefinitionName $roleToAssign -Scope '/'
 ```
 
-> You may need to elevate your access in Azure before being able to create a root scoped assignment.
+> You may need to [elevate your access](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin) in Azure before being able to create a root scoped assignment.
 
 #### Assign Azure role to management group scope
 
@@ -93,7 +93,9 @@ New-AzRoleAssignment -ObjectId $servicePrincipal.Id -RoleDefinitionName $roleToA
 
 ### Azure AD role assignment
 
-Assign `Directory Readers` role to Service Principal/Managed Identity.
+If you intend to pull back roleAssignments or roleEligibilityScheduleRequests (PIM eligible assignments), assign the `Directory Readers` role to the Service Principal or Managed Identity.
+
+> Note: Since AzOps [release 1.9.2](https://github.com/Azure/AzOps/releases/tag/1.9.1), roleAssignments without the enriched properties `DisplayName` and `ObjectType` will be pulled without the `Directory Readers` Azure AD role assigned.
 
 ```powershell
 # Install module

--- a/src/functions/Invoke-AzOpsPull.ps1
+++ b/src/functions/Invoke-AzOpsPull.ps1
@@ -120,7 +120,6 @@
             }
             catch {
                 Write-PSFMessage -Level Warning -String 'Invoke-AzOpsPull.Validating.UserRole.Failed'
-                $SkipRole = $true
                 $SkipPim = $true
             }
         }
@@ -132,7 +131,7 @@
         $resourceTypeDiff = Compare-Object -ReferenceObject $SkipResourceType -DifferenceObject $IncludeResourceType -ExcludeDifferent
         if ($resourceTypeDiff) {
             Write-PSFMessage -Level Warning -Message "SkipResourceType setting conflict found in IncludeResourceType, ignoring $($resourceTypeDiff.InputObject) from IncludeResourceType. To avoid this remove $($resourceTypeDiff.InputObject) from IncludeResourceType or SkipResourceType"
-            $IncludeResourceType = $IncludeResourceType | Where-Object {$_ -notin $resourceTypeDiff.InputObject}
+            $IncludeResourceType = $IncludeResourceType | Where-Object { $_ -notin $resourceTypeDiff.InputObject }
         }
 
         $parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Inherit -Include InvalidateCache, PartialMgDiscovery, PartialMgDiscoveryRoot

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -171,7 +171,7 @@
     'Invoke-AzOpsPull.Validating.AADP2.Success'                                     = 'Azure AD P2 licensing validated' #
     'Invoke-AzOpsPull.Validating.AADP2.Failed'                                      = 'Azure AD P2 licensing not found' #
     'Invoke-AzOpsPull.Validating.UserRole'                                          = 'Asserting fundamental Azure access' #
-    'Invoke-AzOpsPull.Validating.UserRole.Failed'                                   = 'Insufficient access to Azure user data' #
+    'Invoke-AzOpsPull.Validating.UserRole.Failed'                                   = 'Insufficient access to Azure AD. Role Assignments will be pulled, but not enriched with additional data such as DisplayName and ObjectType' #
     'Invoke-AzOpsPull.Validating.UserRole.Success'                                  = 'Azure access validated' #
     'Invoke-AzOpsPull.Validating.ResourceGroupDiscovery.Failed'                     = 'SkipResource set to false or SkipChildResource set to false requires SkipResourceGroup to be set to false. Change value for SkipResourceGroup and retry operation. {0} https://github.com/azure/azops/wiki/settings' #
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Remove `Directory Readers` Azure AD role requirement for `roleAssignments`. Warning message and docs changed to reflect new behavior. 

## This PR fixes/adds/changes/removes

Closing #722 

### Breaking Changes

N/A

## Testing Evidence

Tested in my own environment and can confirm that roleAssignments are pulled back without Directory Reader permissions. 
![image](https://user-images.githubusercontent.com/16622613/205929300-1dacc726-e5ef-4d3d-931a-cf109646944b.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
