### PR TITLE
Fix Release WorkFlow Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,7 @@ jobs:
         run: |
           ./scripts/Version.ps1 -Type ${{ github.event.inputs.type }}
           $Version = (Import-PowerShellDataFile -Path "./src/AzOps.psd1").ModuleVersion
-          $GITHUB_OUTPUT = "version=$Version"
-          Write-Host $GITHUB_OUTPUT
+          echo "version=$Version" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
       - name: "Release"


### PR DESCRIPTION
# Overview/Summary

Corrective update of GitHub Action `release` step Version `$GITHUB_OUTPUT.`
This is to correct wrong update in previous PR #710 

## This PR fixes/adds/changes/removes

1. Changes `release.yml`

### Breaking Changes

1. N/A

## Testing Evidence

I have mocked the workflow in a separate repository and tested with current `main` configuration:
![release version lost](https://user-images.githubusercontent.com/64077181/206259842-d4aa7da0-3774-41d5-8c14-f9f4f68ae3fd.png)
The expected release version information is not appended as expected.

With the update in this PR the result looks like this:
![release version retained](https://user-images.githubusercontent.com/64077181/206260100-6b0390ef-971b-411f-be65-3a0b19be074d.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
