### PR TITLE
Minor correction to Github Command

### DIFF
--- a/docs/wiki/GitHub-Actions.md
+++ b/docs/wiki/GitHub-Actions.md
@@ -1,12 +1,11 @@
 # AzOps Via GitHub
 
-- [AzOps Via GitHub](#azops-via-github)
-  - [Prerequisites](#prerequisites)
-    - [Further reading](#further-reading)
-    - [Important Repository link to refer](#important-repository-link-to-refer)
-    - [Two ways to configure AzOps](#two-ways-to-configure-azops)
-    - [Configure AzOps via Portal](#configure-azops-via-portal)
-    - [Configure via command-line](#configure-via-command-line)
+- [Prerequisites](#prerequisites)
+  - [Further reading](#further-reading)
+  - [Important Repository Link to refer](#important-repository-link-to-refer)
+- [Two ways to configure AzOps](#Two-ways-to-configure-AzOps)
+- [Configure AzOps via Portal](#Configure-AzOps-via-Portal)
+- [Configure via command-line](#Configure-via-command-line)
 
 ## Prerequisites
 

--- a/docs/wiki/GitHub-Actions.md
+++ b/docs/wiki/GitHub-Actions.md
@@ -1,11 +1,12 @@
 # AzOps Via GitHub
 
-- [Prerequisites](#prerequisites)
-  - [Further reading](#further-reading)
-  - [Important Repository Link to refer](#important-repo-link-to-refer)
-- [Two ways to configure AzOps](#Two-ways-to-configure-AzOps)
-- [Configure AzOps via Portal](#Configure-AzOps-via-Portal)
-- [Configure via command-line](#Configure-via-command-line)
+- [AzOps Via GitHub](#azops-via-github)
+  - [Prerequisites](#prerequisites)
+    - [Further reading](#further-reading)
+    - [Important Repository link to refer](#important-repository-link-to-refer)
+    - [Two ways to configure AzOps](#two-ways-to-configure-azops)
+    - [Configure AzOps via Portal](#configure-azops-via-portal)
+    - [Configure via command-line](#configure-via-command-line)
 
 ## Prerequisites
 
@@ -84,7 +85,7 @@ gh api -X PATCH /repos/{owner}/{repo} -f allow_merge_commit=false
 
 ```git
 gh api -X PUT /repos/{owner}/{repo}/actions/permissions/workflow -f default_workflow_permissions='write'
-gh api -X PUT /repos/{owner}/{repo}/actions/permissions/workflow -f can_approve_pull_request_reviews=true
+gh api -X PUT /repos/{owner}/{repo}/actions/permissions/workflow -F can_approve_pull_request_reviews=true
 ```
 
 - Initiate the first Pull workflow


### PR DESCRIPTION
# Summary

Github Command to set can_approve_pull_request_reviews should have upper case -F instead of -f

## This PR fixes below file

1. docs\wiki\GitHub-Actions.md

### Breaking Changes
N/A

## Testing Evidence

Please see issue #732 

## As part of this Pull Request I have

- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
