### PR TITLE
Patch apiVersion on nested microsoft.authorization/policydefinitions resources

### DIFF
--- a/src/internal/functions/Get-AzOpsPolicy.ps1
+++ b/src/internal/functions/Get-AzOpsPolicy.ps1
@@ -38,7 +38,12 @@
             # Process policy definitions
             Write-PSFMessage -Level Verbose -String 'Get-AzOpsResourceDefinition.Processing.Detail' -StringValues 'Policy Definitions', $scopeObject.Scope
             $policyDefinitions = Get-AzOpsPolicyDefinition -ScopeObject $ScopeObject -Subscription $Subscription
-            $policyDefinitions | ConvertTo-AzOpsState -StatePath $StatePath
+            $policyDefinitionsClean = @()
+            foreach ($policyDefinition in $policyDefinitions) {
+                $policyDefinitionClean = $policyDefinition | ConvertTo-Json -Depth 100
+                $policyDefinitionsClean += $policyDefinitionClean -replace 'T00:00:00Z' | ConvertFrom-Json -Depth 100
+            }
+            $policyDefinitionsClean | ConvertTo-AzOpsState -StatePath $StatePath
 
             # Process policy set definitions (initiatives)
             Write-PSFMessage -Level Verbose -String 'Get-AzOpsResourceDefinition.Processing.Detail' -StringValues 'Policy Set Definitions', $ScopeObject.Scope


### PR DESCRIPTION
# Overview/Summary

This PR changes nested resource apiVersion returned by `Az.ResourceGraph` specifically for  `DINE` to remove unwanted information.

## This PR fixes/adds/changes/removes

1. Get-AzOpsPolicy.ps1

### Breaking Changes

N/A

## Testing Evidence

Pull and Push operation of DINE policy with resources tested.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
