### PR TITLE
Adding Removal of Lingering Files

### DIFF
--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -8,6 +8,7 @@ This article answers frequently asked questions relating to AzOps.
   - [In this Section](#in-this-section)
   - [Subscriptions or resources not showing up in repository](#subscriptions-or-resources-not-showing-up-in-repository)
   - [Push fail with deployment already exists in location error](#push-fail-with-deployment-already-exists-in-location-error)
+  - [Does AzOps use temporary files](#does-azops-use-temporary-files)
   - [Pull fail with active pull request already exists error](#pull-fail-with-active-pull-request-already-exists-error)
   - [Discovery scenarios and settings](#discovery-scenarios-and-settings)
     - [**I want to discover all resources across all resource groups in one specific subscription**](#i-want-to-discover-all-resources-across-all-resource-groups-in-one-specific-subscription)
@@ -41,6 +42,14 @@ This happens because [it is unsupported in ARM](https://learn.microsoft.com/en-u
 
 To resolve the error, remove the failed deployment(s) from the target scope and re-run the failed Push pipeline. This can be done either under 'Deployments' at the particular scope in the Azure portal  or with [PowerShell](https://learn.microsoft.com/en-us/powershell/module/az.resources/remove-azmanagementgroupdeployment?view=azps-7.1.0)/[Azure CLI](https://learn.microsoft.com/en-us/cli/azure/deployment/mg?view=azure-cli-latest#az-deployment-mg-delete)/[REST](https://learn.microsoft.com/en-us/rest/api/resources/deployments/delete-at-management-group-scope).
 ![Delete Deployments at scope](./Media/FAQ/delete_deployments.png)
+
+## Does AzOps use Temporary Files
+
+Yes, during runtime AzOps identifies the systems temporary directory `[System.IO.Path]::GetTempPath()`.
+
+AzOps utilizes the temporary directory for storing temporary information either used at processing time by AzOps (e.g., export and conversion of child resources) or information that is intended to be picked up by pipeline after AzOps module execution (e.g., `OUTPUT.md / OUTPUT.json`).
+
+>Due to the different usage patterns of temporary files they are either created and deleted during module invocation or created and left for further processing at a later stage. As a part of AzOps invocation the initialize procedure looks for lingering temporary files (e.g., `OUTPUT.md / OUTPUT.json`) and removes them to ensure a clean execution.
 
 ## Pull fail with active pull request already exists error
 

--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -47,9 +47,9 @@ To resolve the error, remove the failed deployment(s) from the target scope and 
 
 Yes, during runtime AzOps identifies the systems temporary directory `[System.IO.Path]::GetTempPath()`.
 
-AzOps utilizes the temporary directory for storing temporary information either used at processing time by AzOps (e.g., export and conversion of child resources) or information that is intended to be picked up by pipeline after AzOps module execution (e.g., `OUTPUT.md / OUTPUT.json`).
+AzOps utilizes the temporary directory for storing temporary information either used at processing time by AzOps (e.g. export and conversion of child resources) or information that is intended to be picked up by pipeline after AzOps module execution (e.g. `OUTPUT.md / OUTPUT.json`).
 
->Due to the different usage patterns of temporary files they are either created and deleted during module invocation or created and left for further processing at a later stage. As a part of AzOps invocation the initialize procedure looks for lingering temporary files (e.g., `OUTPUT.md / OUTPUT.json`) and removes them to ensure a clean execution.
+>Due to the different usage patterns of temporary files they are either created and deleted during module invocation or created and left for further processing at a later stage. As a part of AzOps invocation the initialize procedure looks for lingering temporary files (e.g. `OUTPUT.md / OUTPUT.json`) and removes them to ensure a clean execution.
 
 ## Pull fail with active pull request already exists error
 

--- a/docs/wiki/Self-Hosted.md
+++ b/docs/wiki/Self-Hosted.md
@@ -13,6 +13,8 @@ AzOps have full support for the use of self-hosted agents/runners and this artic
 For more information about using GitHub Actions self-hosted runners see, [About self-hosted runners](https://docs.github.com/actions/hosting-your-own-runners/about-self-hosted-runners).
 For more information about using Azure DevOps self-hosted agents see, [Azure Pipelines agents](https://learn.microsoft.com/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=browser).
 
+> ⚠️ In case of multiple agents/runners on the same compute resource ensure locking the `Validate` and `Push` pipelines to the same the agent/runner (e.g. using demands with Azure Pipelines)
+
 ## Virtual Machine Scale Sets (VMSS)
 
 Virtual Machine Scale Sets are optimal for hosting your self-hosted agents/runners. They are easy to create and manage and will automatically scale as resource demand changes. To learn more about Virtual Machine Scale Sets see, [Virtual Machine Scale Sets documentation](https://learn.microsoft.com/azure/virtual-machine-scale-sets/).

--- a/docs/wiki/Self-Hosted.md
+++ b/docs/wiki/Self-Hosted.md
@@ -13,7 +13,7 @@ AzOps have full support for the use of self-hosted agents/runners and this artic
 For more information about using GitHub Actions self-hosted runners see, [About self-hosted runners](https://docs.github.com/actions/hosting-your-own-runners/about-self-hosted-runners).
 For more information about using Azure DevOps self-hosted agents see, [Azure Pipelines agents](https://learn.microsoft.com/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=browser).
 
-> ⚠️ In case of multiple agents/runners on the same compute resource ensure locking the `Validate` and `Push` pipelines to the same the agent/runner (e.g. using demands with Azure Pipelines)
+> ⚠️ In case of multiple agents/runners on the same compute resource ensure locking the `Validate` and `Push` pipelines to the same the agent/runner (e.g. using [demands with Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml))
 
 ## Virtual Machine Scale Sets (VMSS)
 

--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -69,6 +69,14 @@
             Write-PSFMessage -Level Warning -String 'Initialize-AzOpsEnvironment.ThrottleLimit.Adjustment' -StringValues $throttleLimit, $cpuCores
             Set-PSFConfig -Module AzOps -Name Core.ThrottleLimit -Value 5
         }
+
+        # Remove lingering files from previous run
+        $tempPath = [System.IO.Path]::GetTempPath()
+        if (Test-Path -Path ($tempPath + 'OUTPUT.md')) {
+            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile.Remove'
+            Remove-Item -Path ($tempPath + 'OUTPUT.md') -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path ($tempPath + 'OUTPUT.json') -Force -ErrorAction SilentlyContinue
+        }
     }
 
     process {

--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -69,14 +69,6 @@
             Write-PSFMessage -Level Warning -String 'Initialize-AzOpsEnvironment.ThrottleLimit.Adjustment' -StringValues $throttleLimit, $cpuCores
             Set-PSFConfig -Module AzOps -Name Core.ThrottleLimit -Value 5
         }
-
-        # Remove lingering files from previous run
-        $tempPath = [System.IO.Path]::GetTempPath()
-        if (Test-Path -Path ($tempPath + 'OUTPUT.md')) {
-            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile.Remove'
-            Remove-Item -Path ($tempPath + 'OUTPUT.md') -Force -ErrorAction SilentlyContinue
-            Remove-Item -Path ($tempPath + 'OUTPUT.json') -Force -ErrorAction SilentlyContinue
-        }
     }
 
     process {

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -171,6 +171,14 @@
 
         $WhatIfPreferenceState = $WhatIfPreference
         $WhatIfPreference = $false
+
+        # Remove lingering files from previous run
+        $tempPath = [System.IO.Path]::GetTempPath()
+        if (Test-Path -Path ($tempPath + 'OUTPUT.md')) {
+            Write-PSFMessage -Level Verbose -String 'Set-AzOpsWhatIfOutput.WhatIfFile.Remove'
+            Remove-Item -Path ($tempPath + 'OUTPUT.md') -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path ($tempPath + 'OUTPUT.json') -Force -ErrorAction SilentlyContinue
+        }
     }
 
     process {

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -280,4 +280,5 @@
     'Set-AzOpsWhatIfOutput.WhatIfFileMax'                                           = 'WhatIf markdown and json files have reached character limit, unable to append more information to files. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
     'Set-AzOpsWhatIfOutput.WhatIfMessageMax'                                        = 'WhatIf have reached maximum character limit, unable to append warning message. WhatIf is too large for comment field, for more details look at PR files to determine changes.' # $ResultSizeMaxLimit, $ResultSizeLimit
     'Set-AzOpsWhatIfOutput.WhatIfResults'                                           = 'WhatIf Output {0}' # $results
+    'Set-AzOpsWhatIfOutput.WhatIfFile.Remove'                                       = 'Removing WhatIf markdown and json files lingering from previous run' #
 }


### PR DESCRIPTION
# Overview/Summary

This PR fixes #754 

- Adds Logic in `Invoke-AzOpsPush` to check for temporary lingering files from previous executions and removes them.
- Adds Guidance in Wiki FAQ about temporary files.
- Adds Self-Hosted section when multiple agents/runners co-exists on the same compute resource.

## This PR fixes/adds/changes/removes

1.  Changes `Frequently-Asked-Questions.md`
2.  Changes `Self-Hosted.md`
3.  Changes `Invoke-AzOpsPush.ps1`
4. Changes `Strings.psd1`

### Breaking Changes

N/A

## Testing Evidence

Removal logic has been tested and files are removed successfully.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
