### PR TITLE
Throw exception on failing bicep build

### DIFF
--- a/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
+++ b/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
@@ -23,6 +23,10 @@
         $transpiledTemplatePath = $BicepTemplatePath -replace '\.bicep', '.json'
         Write-PSFMessage -Level Verbose -String 'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate' -StringValues $BicepTemplatePath, $transpiledTemplatePath
         Invoke-AzOpsNativeCommand -ScriptBlock { bicep build $bicepTemplatePath --outfile $transpiledTemplatePath }
+        if(-not (Test-Path $transpiledTemplatePath)){
+            Write-PSFMessage -Level Warning -String 'ConvertFrom-AzOpsBicepTemplate.Resolve.Warning' -StringValues $BicepTemplatePath
+            throw
+        }
         # Return transpiled ARM json path
         return $transpiledTemplatePath
     }

--- a/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
+++ b/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
@@ -23,8 +23,10 @@
         $transpiledTemplatePath = $BicepTemplatePath -replace '\.bicep', '.json'
         Write-PSFMessage -Level Verbose -String 'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate' -StringValues $BicepTemplatePath, $transpiledTemplatePath
         Invoke-AzOpsNativeCommand -ScriptBlock { bicep build $bicepTemplatePath --outfile $transpiledTemplatePath }
-        if(-not (Test-Path $transpiledTemplatePath)){
-            Write-PSFMessage -Level Warning -String 'ConvertFrom-AzOpsBicepTemplate.Resolve.Warning' -StringValues $BicepTemplatePath
+        # Check if bicep build created (ARM) template
+        if (-not (Test-Path $transpiledTemplatePath)) {
+            # If bicep build did not produce file exit with error
+            Write-PSFMessage -Level Error -String 'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate.Error' -StringValues $BicepTemplatePath
             throw
         }
         # Return transpiled ARM json path

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -52,7 +52,7 @@
     'AzOpsScope.ChildResource.InitializeMemberVariables'                            = 'Determine scope of Child Resource based on ResourceType {0}, Resource Name {1} and Parent ResourceID {2}' # ResourceType, Resource Name, Parent ResourceId
 
     'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate'                   = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $BicepTemplatePath, $transpiledTemplatePath
-    'ConvertFrom-AzOpsBicepTemplate.Resolve.Warning'                                = 'Failed converting Bicep template ({0})' # $BicepTemplatePath
+    'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate.Error'             = 'Failed to convert Bicep template ({0}) to standard ARM Template JSON' # $BicepTemplatePath
 
     'ConvertTo-AzOpsState.Exporting'                                                = 'Exporting AzOpsState to {0}' # $resourceData.ObjectFilePath
     'ConvertTo-AzOpsState.Exporting.Default'                                        = 'Exporting input resource to AzOpsState to {0}' # $resourceData.ObjectFilePath

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -52,6 +52,7 @@
     'AzOpsScope.ChildResource.InitializeMemberVariables'                            = 'Determine scope of Child Resource based on ResourceType {0}, Resource Name {1} and Parent ResourceID {2}' # ResourceType, Resource Name, Parent ResourceId
 
     'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate'                   = 'Converting Bicep template ({0}) to standard ARM Template JSON ({1})' # $BicepTemplatePath, $transpiledTemplatePath
+    'ConvertFrom-AzOpsBicepTemplate.Resolve.Warning'                                = 'Failed converting Bicep template ({0})' # $BicepTemplatePath
 
     'ConvertTo-AzOpsState.Exporting'                                                = 'Exporting AzOpsState to {0}' # $resourceData.ObjectFilePath
     'ConvertTo-AzOpsState.Exporting.Default'                                        = 'Exporting input resource to AzOpsState to {0}' # $resourceData.ObjectFilePath

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -308,6 +308,8 @@ Describe "Repository" {
         $script:bicepDeploymentName = "AzOps-{0}-{1}" -f $($script:bicepTemplatePath[0].Name.Replace(".bicep", '')), $deploymentLocationId
         $script:bicepResourceGroupName = ((Get-Content -Path ($Script:bicepTemplatePath.FullName[1])) | ConvertFrom-Json).parameters.resourceGroupName.value
 
+        $script:bicepErrorTemplatePath = Get-Item -Path "$($global:testRoot)/templates/biceperror.bicep" | Copy-Item -Destination $script:resourceGroupDirectory -PassThru -Force
+
         $script:pushmgmttest1idManagementGroupTemplatePath = Get-Item "$($global:testroot)/templates/pushmgmttest1displayname (pushmgmttest1id)" | Copy-Item -Destination $script:testManagementGroupDirectory -Recurse -PassThru -Force
         $script:pushmgmttest1idManagementGroupDeploymentName = "AzOps-{0}-{1}" -f "$($script:pushmgmttest1idManagementGroupTemplatePath[1].Name.Replace(".json", ''))", $deploymentLocationId
         $script:pushmgmttest1idName = ((Get-Content -Path ($script:pushmgmttest1idManagementGroupTemplatePath.FullName[1])) | ConvertFrom-Json).resources.name[0]
@@ -995,6 +997,15 @@ Describe "Repository" {
             )
             $DeleteSetContents = (Get-Content $script:policyAssignmentsDep2File)
             {Invoke-AzOpsPush -ChangeSet $changeSet -DeleteSetContents $deleteSetContents -WhatIf:$true} | Should -Throw
+        }
+        #endregion
+
+        #region Bicep Build Validation
+        It "Build of invalid bicep file should fail" {
+            $changeSet = @(
+                "A`t$($script:bicepErrorTemplatePath.FullName)"
+            )
+            {Invoke-AzOpsPush -ChangeSet $changeSet} | Should -Throw
         }
         #endregion
     }

--- a/src/tests/templates/biceperror.bicep
+++ b/src/tests/templates/biceperror.bicep
@@ -1,0 +1,19 @@
+param staName string = 'eroazops${uniqueString(resourceGroup().id)}'
+param location string = resourceGroup().location
+
+resource storage_resource 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: staName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties000: {
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      bypass: 'None'
+      defaultOction: 'MaybeGivesError'
+    }
+    supportsHttpsTrafficOnly: true
+  }
+}


### PR DESCRIPTION
Throw exception on failing bicep build.

Updated logic to solve: https://github.com/Azure/AzOps/issues/767
Added check in ConvertFrom-AzOpsBicepTemplate to see if the bicep build command was able to create its output file as a result of the bicep build command.
Without this, the exception is swallowed in validate/push pipelines.

## This PR fixes/adds/changes/removes

1. adds exception if bicep build failed, and no transpiled file was created

### Breaking Changes
N/A

## Testing Evidence

Tested if exception was throwed when it was required, automated test case added to catch code regression.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
