### PR TITLE
Bug fix for UMI and add support for parameterize policy assignment

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.jq
@@ -1,1 +1,47 @@
-del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy)
+. |
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {
+        "scope": {
+            "type": "string",
+            "defaultValue": .Properties.scope
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": .Location
+        },
+        "policyparameters": {
+            "type": "object",
+            "defaultValue": .Properties.parameters
+        },
+        "identity": {
+            "type": "object",
+            "defaultValue": (if (.Identity.Type == "SystemAssigned" ) then {type: "SystemAssigned",PrincipalId:.Identity.PrincipalId,TenantId:.Identity.TenantId} else {type: "UserAssigned", UserAssignedIdentities : { (.Identity.UserAssignedIdentities | to_entries[] | .key) : {} } } end)
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": .Type,
+            "name": .Name,
+            "apiVersion": "2022-06-01",
+            "location": "[parameters('location')]",
+            "identity": "[parameters('identity')]",
+            "properties": {
+                "description": .Properties.Description,
+                "displayName":  .Properties.displayName,
+                "enforcementMode": .Properties.enforcementMode,
+                "policyDefinitionId": .Properties.policyDefinitionId,
+                "scope": .Properties.scope,
+                "parameters": "[parameters('policyparameters')]"
+            }
+        }
+    ],
+    "outputs": {}
+} | del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy )


### PR DESCRIPTION
Include Support for Parameters for Policy assignment and handle UMI

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

**Breaking change to underlying data model for Templates.**

Updating JQ template for following:

1. Bug fix for UMI where PrincipalId and ClientId causes ARM template deployment failure.
2. Adding support for parameterising policy assignment template portable across tenants.

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
3. *Replace me*
4. *Replace me*

### Breaking Changes

**Breaking change to underlying data model for Templates.**

## Testing Evidence
<img width="2216" alt="image" src="https://user-images.githubusercontent.com/14359777/224847988-c6c6c15c-23ac-4271-8735-66c9b847086d.png">


## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
