### PR TITLE
Fix regression of #538

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.jq
@@ -1,1 +1,2 @@
+if .identity.userAssignedIdentities != null then del(.identity.userAssignedIdentities[].principalId, .identity.userAssignedIdentities[].clientId, .identity.tenantId, .identity.principalId) else . end |
 del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy)

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -659,9 +659,6 @@ Describe "Repository" {
             $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
             $fileContents.resources[0].identity.userAssignedIdentities | Should -BeTrue
         }
-        It "Policy Assignments with UAM custom metadata property should exist" {
-            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
-            $fileContents.resources[0].properties.metadata.customkey | Should -BeTrue
         }
         It "Policy Assignments with UAM deployment should be successful" {
             $script:policyAssignmentUamDeployment = Get-AzResourceGroupDeployment -Name $script:policyAssignmentsUamDeploymentName -ResourceGroupName $script:policyAssignmentsUam.ResourceGroupName

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -67,6 +67,7 @@ Describe "Repository" {
         try {
             New-AzSubscriptionDeployment -Name 'AzOps-Tests-rbacdep' -Location northeurope -TemplateFile "$($global:testRoot)/templates/rbactest.bicep" -TemplateParameterFile "$($global:testRoot)/templates/rbactest.parameters.json"
             New-AzManagementGroupDeployment @params
+            New-AzResourceGroupDeployment -Name 'AzOps-Tests-policyuam' -ResourceGroupName App1-azopsrg -TemplateFile "$($global:testRoot)/templates/policywithuam.bicep"
             # Pause for resource consistency
             Start-Sleep -Seconds 120
         }
@@ -123,6 +124,7 @@ Describe "Repository" {
             $script:policyAssignments = Get-AzPolicyAssignment -Name "TestPolicyAssignment" -Scope "/providers/Microsoft.Management/managementGroups/$($script:managementManagementGroup.Name)"
             $script:policyAssignmentsDep = Get-AzPolicyAssignment -Name "AzOpsDep2 - audit-vm-manageddisks"
             $script:policyAssignmentsDep2 = Get-AzPolicyAssignment -Name "TestPolicyAssignment2" -Scope "/subscriptions/$script:subscriptionId/resourceGroups/Lock2-azopsrg"
+            $script:policyAssignmentsUam = Get-AzPolicyAssignment -Name "TestPolicyAssignmentWithUAM" -Scope "/subscriptions/$script:subscriptionId/resourceGroups/App1-azopsrg"
             $script:policyDefinitions = Get-AzPolicyDefinition -Name 'TestPolicyDefinition' -ManagementGroupName $($script:testManagementGroup.Name)
             $script:policyDefinitionsDep = Get-AzPolicyDefinition -Name 'TestPolicyDefinitionDep' -ManagementGroupName $($script:testManagementGroup.Name)
             $script:policyDefinitionsDep2 = Get-AzPolicyDefinition -Name 'TestPolicyDefinitionDe2' -ManagementGroupName $($script:testManagementGroup.Name)
@@ -234,6 +236,12 @@ Describe "Repository" {
         $script:policyAssignmentsDep2DeploymentName = "AzOps-{0}-{1}" -f $($script:policyAssignmentsDep2Path.Name.Replace(".json", '')).Substring(0, 53), $deploymentLocationId
         Write-PSFMessage -Level Debug -Message "PolicyAssignmentsFile: $($script:policyAssignmentsDep2File)" -FunctionName "BeforeAll"
 
+        $script:policyAssignmentsUamPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_policyassignments-$(($script:policyAssignmentsUam.Name).toLower()).json")
+        $script:policyAssignmentsUamDirectory = ($script:policyAssignmentsUamPath).Directory
+        $script:policyAssignmentsUamFile = ($script:policyAssignmentsUamPath).FullName
+        $script:policyAssignmentsUamDeploymentName = "AzOps-{0}-{1}" -f $($script:policyAssignmentsUamPath.Name.Replace(".json", '')).Substring(0, 53), $deploymentLocationId
+        Write-PSFMessage -Level Debug -Message "PolicyAssignmentsFile: $($script:policyAssignmentsUamFile)" -FunctionName "BeforeAll"
+
         $script:policyDefinitionsPath = ($filePaths | Where-Object Name -eq "microsoft.authorization_policydefinitions-$(($script:policyDefinitions.Name).toLower()).parameters.json")
         $script:policyDefinitionsDirectory = ($script:policyDefinitionsPath).Directory
         $script:policyDefinitionsFile = ($script:policyDefinitionsPath).FullName
@@ -321,6 +329,7 @@ Describe "Repository" {
         $changeSet = @(
             "A`t$script:testManagementGroupFile",
             "A`t$script:policyAssignmentsFile",
+            "A`t$script:policyAssignmentsUamFile",
             "A`t$script:policyDefinitionsFile",
             "A`t$script:policySetDefinitionsFile",
             "A`t$script:policyExemptionsFile",
@@ -616,6 +625,47 @@ Describe "Repository" {
         It "Policy Assignments deletion should be successful" {
             $policyAssignmentDeletion = Get-AzPolicyAssignment -Id $script:policyAssignments.PolicyAssignmentId -ErrorAction SilentlyContinue
             $policyAssignmentDeletion | Should -Be $Null
+        }
+        #endregion
+
+        #region Scope = Policy Assignments with UAM - Resource Group (./root/tenant root group/test/platform/management/subscription-0/App1-azopsrg)
+        It "Policy Assignments with UAM directory should exist" {
+            Test-Path -Path $script:policyAssignmentsUamDirectory | Should -BeTrue
+        }
+        It "Policy Assignments with UAM file should exist" {
+            Test-Path -Path $script:policyAssignmentsUamFile | Should -BeTrue
+        }
+        It "Policy Assignments with UAM resource type should exist" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -BeTrue
+        }
+        It "Policy Assignments with UAM resource name should exist" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].name | Should -BeTrue
+        }
+        It "Policy Assignments with UAM resource apiVersion should exist" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].apiVersion | Should -BeTrue
+        }
+        It "Policy Assignments with UAM resource properties should exist" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].properties | Should -BeTrue
+        }
+        It "Policy Assignments with UAM resource type should match" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -Be "Microsoft.Authorization/policyAssignments"
+        }
+        It "Policy Assignments with UAM scope property should match" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].identity.userAssignedIdentities | Should -BeTrue
+        }
+        It "Policy Assignments with UAM custom metadata property should exist" {
+            $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].properties.metadata.customkey | Should -BeTrue
+        }
+        It "Policy Assignments with UAM deployment should be successful" {
+            $script:policyAssignmentUamDeployment = Get-AzResourceGroupDeployment -Name $script:policyAssignmentsUamDeploymentName -ResourceGroupName $script:policyAssignmentsUam.ResourceGroupName
+            $policyAssignmentUamDeployment.ProvisioningState | Should -Be "Succeeded"
         }
         #endregion
 

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -659,7 +659,6 @@ Describe "Repository" {
             $fileContents = Get-Content -Path $script:policyAssignmentsUamFile -Raw | ConvertFrom-Json -Depth 25
             $fileContents.resources[0].identity.userAssignedIdentities | Should -BeTrue
         }
-        }
         It "Policy Assignments with UAM deployment should be successful" {
             $script:policyAssignmentUamDeployment = Get-AzResourceGroupDeployment -Name $script:policyAssignmentsUamDeploymentName -ResourceGroupName $script:policyAssignmentsUam.ResourceGroupName
             $policyAssignmentUamDeployment.ProvisioningState | Should -Be "Succeeded"

--- a/src/tests/templates/policywithuam.bicep
+++ b/src/tests/templates/policywithuam.bicep
@@ -1,0 +1,25 @@
+param policyAssignmentName string = 'TestPolicyAssignmentWithUAM'
+param policyDefinitionID string = '/providers/Microsoft.Authorization/policyDefinitions/014664e7-e348-41a3-aeb9-566e4ff6a9df'
+param location string = resourceGroup().location
+param uamName string = 'TestAzOpsUAM'
+
+targetScope = 'resourceGroup'
+
+resource uam 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+    name: uamName
+    location: location
+}
+
+resource assignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+    name: policyAssignmentName
+    location: location
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            '${uam.id}': {}
+        }
+    }
+    properties: {
+        policyDefinitionId: policyDefinitionID
+    }
+}


### PR DESCRIPTION
# Overview/Summary

This PR adds logic that was fixed back in `1.7.2` #538 , but was regressed in `2.0.0` affecting deployability of policy assignments with userAssignedIdentities. It also contains automated testing to catch similar regressions moving forward.

## This PR fixes/adds/changes/removes

1. Changes `policyAssignments.jq`
2. Changes `Repository.Tests.ps1`
3. Adds `policywithuam.bicep`

### Breaking Changes

N/A

## Testing Evidence

Testing is included in automated pr validation.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
