### PR TITLE
Fix regression of Subscription Only Discovery with no Management Group

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
     # - name: OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
     #   uses: azure/login@v1
     #   with:
-    #     client-id: ${{ env.ARM_CLIENT_ID}}
+    #     client-id: ${{ env.ARM_CLIENT_ID }}
     #     tenant-id: ${{ env.ARM_TENANT_ID }}
     #     subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
     #     enable-AzPSSession: true
@@ -87,6 +87,61 @@ jobs:
         shell: pwsh
         run: |
           ./src/tests/Pester.ps1 -TestIntegration $true
+
+      # Run Cleanup Environment
+      - name: "Run Environment Cleanup"
+        shell: pwsh
+        run: |
+          ./src/tests/Pester.ps1 -CleanupEnvironment $true
+  testsubonly:
+    if: ${{ always() }}
+    needs: tests
+    name: "Tests - Subscription Only"
+    runs-on: ubuntu-latest
+    environment: test
+    env:
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_SUB }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_SUB }}
+
+    steps:
+
+      # Checkout
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      # Dependencies
+      - name: "Dependencies"
+        shell: pwsh
+        run: |
+          ./scripts/Dependencies.ps1
+
+      # Connect to Azure - TEMPORARY until 2.7.0 credential expiration issue is fixed
+      - name: "Connect"
+        shell: pwsh
+        run: |
+          $credential = New-Object PSCredential -ArgumentList $env:ARM_CLIENT_ID, (ConvertTo-SecureString -String $env:ARM_CLIENT_SECRET -AsPlainText -Force)
+          Connect-AzAccount -TenantId $env:ARM_TENANT_ID -ServicePrincipal -Credential $credential -SubscriptionId $env:ARM_SUBSCRIPTION_ID
+
+    # # Authenticate Azure context
+    # - name: OIDC Login to Azure Public Cloud with AzPowershell (enableAzPSSession true)
+    #   uses: azure/login@v1
+    #   with:
+    #     client-id: ${{ env.ARM_CLIENT_ID_SUB }}
+    #     tenant-id: ${{ env.ARM_TENANT_ID }}
+    #     subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+    #     enable-AzPSSession: true
+
+      # Run Subscription Only Tests
+      - name: "Run Subscription Only Tests"
+        shell: pwsh
+        run: |
+          ./src/tests/Pester.ps1 -TestSubscriptionOnly $true
 
       # Run Cleanup Environment
       - name: "Run Environment Cleanup"

--- a/src/data/template/Microsoft.Subscription/subscriptions.template.jq
+++ b/src/data/template/Microsoft.Subscription/subscriptions.template.jq
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "type": .Type,
+            "name": .Name,
+            "apiVersion": "0000-00-00",
+            "tags": .Tags
+        }
+    ],
+    "outputs": {}
+} |
+.resources[].tags |= if . != null then to_entries | sort_by(.key) | from_entries else . end
+| del(.. | select(. == null))
+| del(.. | select(. == ""))

--- a/src/functions/Invoke-AzOpsPull.ps1
+++ b/src/functions/Invoke-AzOpsPull.ps1
@@ -169,6 +169,7 @@
         else {
             # If no management groups are found, iterate through each subscription
             foreach ($subscription in $script:AzOpsSubscriptions) {
+                ConvertTo-AzOpsState -Resource (Get-AzSubscription -SubscriptionId $subscription.subscriptionId) -StatePath $StatePath
                 Get-AzOpsResourceDefinition -Scope $subscription.id @parameters
             }
         }

--- a/src/internal/functions/ConvertTo-AzOpsState.ps1
+++ b/src/internal/functions/ConvertTo-AzOpsState.ps1
@@ -135,6 +135,9 @@
             { $_ -is [Microsoft.Azure.Commands.Profile.Models.PSAzureSubscription] } {
                 Write-PSFMessage -Level Verbose -String 'ConvertTo-AzOpsState.ObjectType.Resolved.PSObject' -StringValues "$($_.GetType())" -FunctionName 'ConvertTo-AzOpsState'
                 $resourceType = 'Microsoft.Subscription/subscriptions'
+                if (-not $Resource.Type) {
+                    $Resource | Add-Member -NotePropertyName Type -NotePropertyValue $resourceType
+                }
                 break
             }
             # Resource Groups

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -178,7 +178,7 @@ Describe "Repository" {
         }
         #endregion GeneratedRoot Pull
 
-        # The following values are discovering the file system paths so that they can be validate against ensuring that the data model behaves as intended.
+        # The following values are discovering the file system paths so that they can be validate, ensuring that the data model behaves as intended.
 
         #region Paths
         Write-PSFMessage -Level Debug -Message "GeneratedRootPath: $generatedRoot" -FunctionName "BeforeAll"

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -178,7 +178,7 @@ Describe "Repository" {
         }
         #endregion GeneratedRoot Pull
 
-        # The following values are discovering the file system paths so that they can be validate, ensuring that the data model behaves as intended.
+        # The following values are discovering the file system paths, ensuring that the model behaves as intended.
 
         #region Paths
         Write-PSFMessage -Level Debug -Message "GeneratedRootPath: $generatedRoot" -FunctionName "BeforeAll"

--- a/src/tests/subscriptiononly/SubOnly.Tests.ps1
+++ b/src/tests/subscriptiononly/SubOnly.Tests.ps1
@@ -1,0 +1,243 @@
+﻿<#
+SubOnly.Tests.ps1
+The tests within this file validate that the `Invoke-AzOpsPull` function is invoking as expected with the correct output data.
+This file must be invoked by the Pester.ps1 file as the Global variable testroot is required for invocation.
+#>
+
+Describe "SubscriptionOnly" {
+
+    BeforeAll {
+
+        Write-PSFMessage -Level Verbose -Message "Initializing test environment" -FunctionName "BeforeAll"
+
+        # Suppress the breaking change warning messages in Azure PowerShell
+        Set-Item -Path  Env:\SuppressAzurePowerShellBreakingChangeWarnings -Value $true
+
+        <#
+        Script Isolation
+        https://github.com/pester/Pester/releases/tag/5.2.0
+        #>
+
+        $script:repositoryRoot = (Resolve-Path "$global:testroot/../..").Path
+        $script:tenantId = $env:ARM_TENANT_ID
+        $script:subscriptionId = $env:ARM_SUBSCRIPTION_ID
+
+        # Validate that the runtime variables are set as they are used to authenticate the Azure session.
+
+        if ($null -eq $script:tenantId) {
+            Write-PSFMessage -Level Critical -Message "Unable to validate environment variable ARM_TENANT_ID"
+            throw
+        }
+        if ($null -eq $script:subscriptionId) {
+            Write-PSFMessage -Level Critical -Message "Unable to validate environment variable ARM_SUBSCRIPTION_ID"
+            throw
+        }
+
+        # Ensure PowerShell has an authenticate Azure Context which the tests can run within and generate data as needed
+
+        Write-PSFMessage -Level Verbose -Message "Validating Azure context" -FunctionName "BeforeAll"
+        $tenant = (Get-AzContext -ListAvailable -ErrorAction SilentlyContinue).Tenant.Id
+        if ($tenant -inotcontains "$script:tenantId") {
+            Write-PSFMessage -Level Verbose -Message "Authenticating Azure session" -FunctionName "BeforeAll"
+            if ($env:USER -eq "vsts") {
+                # Platform: Azure Pipelines
+                $credential = New-Object PSCredential -ArgumentList $env:ARM_CLIENT_ID, (ConvertTo-SecureString -String $env:ARM_CLIENT_SECRET -AsPlainText -Force)
+                $null = Connect-AzAccount -TenantId $script:tenantId -ServicePrincipal -Credential $credential -SubscriptionId $script:subscriptionId -WarningAction SilentlyContinue
+            }
+        }
+        else {
+            $null = Set-AzContext -TenantId $script:tenantId -SubscriptionId $script:subscriptionId
+        }
+
+        # Deploy the Azure environment based upon prefined resource templates which will generate a matching file system hierachy
+
+        Write-PSFMessage -Level Verbose -Message "Creating repository test environment" -FunctionName "BeforeAll"
+        try {
+            $rg = New-AzSubscriptionDeployment -Name 'AzOps-Tests-SubOnly-RG' -Location 'northeurope'  -TemplateParameterFile "$($global:testRoot)/templates/rgsubonlydeploy.parameters.json" -TemplateFile "$($global:testRoot)/templates/rgsubonlydeploy.bicep"
+            $sta = New-AzResourceGroupDeployment -Name 'AzOps-Tests-SubOnly-Sta' -ResourceGroupName $rg.Parameters.resourceGroupName.Value -TemplateFile "$($global:testRoot)/templates/stasubonlydeploy.bicep"
+            # Pause for resource consistency
+            Start-Sleep -Seconds 120
+        }
+        catch {
+            Write-PSFMessage -Level Critical -Message "Deployment of repository test failed" -Exception $_.Exception
+            throw
+        }
+
+        # Ensure that the root directories does not exist before running tests.
+
+        Write-PSFMessage -Level Verbose -Message "Testing for root directory existence" -FunctionName "BeforeAll"
+        $generatedRoot = Join-Path -Path $script:repositoryRoot -ChildPath "root"
+        if (Test-Path -Path $generatedRoot) {
+            Write-PSFMessage -Level Verbose -Message "Removing $generatedRoot directory" -FunctionName "BeforeAll"
+            Remove-Item -Path $generatedRoot -Recurse
+        }
+
+        # The following values match the Resource Template which we deploy the platform services with these need to match so that the lookups within the filesystem are aligned.
+
+        try {
+            Set-AzContext -SubscriptionId $script:subscriptionId
+            $script:subscription = (Get-AzSubscription | Where-Object Id -eq $script:subscriptionId)
+            $script:resourceGroup = (Get-AzResourceGroup | Where-Object ResourceGroupName -eq $sta.ResourceGroupName)
+            $script:storageAccount = Get-AzResource -Name $sta.Parameters.staName.Value -ResourceGroupName $script:resourceGroup.ResourceGroupName
+        }
+        catch {
+            Write-PSFMessage -Level Critical -Message "Failed to get deployed services" -Exception $_.Exception -FunctionName "BeforeAll"
+        }
+
+        # Invoke the Invoke-AzOpsPull function to generate the scope data which can be tested against to ensure structure is correct and data model hasn't changed.
+
+        #region GeneratedRoot Pull
+        Set-PSFConfig -FullName AzOps.Core.State -Value $generatedRoot
+        Set-PSFConfig -FullName AzOps.Core.DefaultDeploymentRegion -Value "northeurope"
+        $deploymentLocationId = (Get-FileHash -Algorithm SHA256 -InputStream ([IO.MemoryStream]::new([byte[]][char[]](Get-PSFConfigValue -FullName 'AzOps.Core.DefaultDeploymentRegion')))).Hash.Substring(0, 4)
+
+        Write-PSFMessage -Level Verbose -Message "Generating folder structure" -FunctionName "BeforeAll"
+        try {
+            Initialize-AzOpsEnvironment
+            Invoke-AzOpsPull -SkipRole:$false -SkipPolicy:$false -SkipResource:$false
+        }
+        catch {
+            Write-PSFMessage -Level Critical -Message "Initialize failed" -Exception $_.Exception
+            throw
+        }
+        #endregion GeneratedRoot Pull
+
+        # The following values are discovering the file system paths so that they can be validate, ensuring that the data model behaves as intended.
+
+        #region Paths
+        Write-PSFMessage -Level Debug -Message "GeneratedRootPath: $generatedRoot" -FunctionName "BeforeAll"
+
+        $filePaths = (Get-ChildItem -Path $generatedRoot -Recurse)
+
+        $script:subscriptionPath = ($filePaths | Where-Object Name -eq "microsoft.subscription_subscriptions-$(($script:subscription.Id).toLower()).json")
+        $script:subscriptionDirectory = ($script:subscriptionPath).Directory
+        $script:subscriptionFile = ($script:subscriptionPath).FullName
+        Write-PSFMessage -Level Debug -Message "SubscriptionFile: $($script:subscriptionFile)" -FunctionName "BeforeAll"
+
+        $script:resourceGroupPath = ($filePaths | Where-Object Name -eq "microsoft.resources_resourcegroups-$(($script:resourceGroup.ResourceGroupName).toLower()).json")
+        $script:resourceGroupDirectory = ($script:resourceGroupPath).Directory
+        $script:resourceGroupFile = ($script:resourceGroupPath).FullName
+        $script:resourceGroupDeploymentName = "AzOps-{0}-{1}" -f $($script:resourceGroupPath.Name.Replace(".json", '')).Substring(0, 53), $deploymentLocationId
+        Write-PSFMessage -Level Debug -Message "ResourceGroupFile: $($script:resourceGroupFile)" -FunctionName "BeforeAll"
+
+        $script:storageAccountPath = ($filePaths | Where-Object Name -eq "microsoft.storage_storageaccounts-$(($script:storageAccount.Name).toLower()).json")
+        $script:storageAccountDirectory = ($script:storageAccountPath).Directory
+        $script:storageAccountFile = ($script:storageAccountPath).FullName
+        $script:storageAccountDeploymentName = "AzOps-{0}-{1}" -f $($script:storageAccountPath.Name.Replace(".json", '')).Substring(0, 53), $deploymentLocationId
+        Write-PSFMessage -Level Debug -Message "StorageAccountFile: $($script:storageAccountFile)" -FunctionName "BeforeAll"
+        #endregion Paths
+
+        #Test push based on pulled resources
+        $changeSet = @(
+            "A`t$script:resourceGroupFile",
+            "A`t$script:storageAccountFile"
+        )
+        Invoke-AzOpsPush -ChangeSet $changeSet
+    }
+
+    Context "Test" {
+
+        #region
+        # Scope - Root (./root)
+        It "Root directory should exist" {
+            Test-Path -Path $generatedRoot | Should -BeTrue
+        }
+        #endregion
+
+        #region Scope - Subscription (./root/subscription-0)
+        It "Subscription directory should exist" {
+            Test-Path -Path $script:subscriptionDirectory | Should -BeTrue
+        }
+        It "Subscription file should exist" {
+            Test-Path -Path $script:subscriptionFile | Should -BeTrue
+        }
+        It "Subscription resource type should exist" {
+            $fileContents = Get-Content -Path $script:subscriptionFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -BeTrue
+        }
+        It "Subscription resource name should exist" {
+            $fileContents = Get-Content -Path $script:subscriptionFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].name | Should -BeTrue
+        }
+        It "Subscription resource apiVersion should exist" {
+            $fileContents = Get-Content -Path $script:subscriptionFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].apiVersion | Should -BeTrue
+        }
+        It "Subscription resource type should match" {
+            $fileContents = Get-Content -Path $script:subscriptionFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -Be "Microsoft.Subscription/subscriptions"
+        }
+        #endregion
+
+        #region Scope - Resource Group (./root/subscription-0/TestSubOnly-azopsrg)
+        It "Resource Group directory should exist" {
+            Test-Path -Path $script:resourceGroupDirectory | Should -BeTrue
+        }
+        It "Resource Group file should exist" {
+            Test-Path -Path $script:resourceGroupFile | Should -BeTrue
+        }
+        It "Resource Group resource type should exist" {
+            $fileContents = Get-Content -Path $script:resourceGroupFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -BeTrue
+        }
+        It "Resource Group resource name should exist" {
+            $fileContents = Get-Content -Path $script:resourceGroupFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].name | Should -BeTrue
+        }
+        It "Resource Group resource apiVersion should exist" {
+            $fileContents = Get-Content -Path $script:resourceGroupFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].apiVersion | Should -BeTrue
+        }
+        It "Resource Group resource properties should exist" {
+            $fileContents = Get-Content -Path $script:resourceGroupFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].properties | Should -BeTrue
+        }
+        It "Resource Group resource type should match" {
+            $fileContents = Get-Content -Path $script:resourceGroupFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -Be "Microsoft.Resources/resourceGroups"
+        }
+        It "Resource Group deployment should be successful" {
+            $script:resourceGroupDeployment = Get-AzSubscriptionDeployment -Name $script:resourceGroupDeploymentName
+            $resourceGroupDeployment.ProvisioningState | Should -Be "Succeeded"
+        }
+        #endregion
+
+        #region Scope - Route Table (./root/subscription-0/TestSubOnly-azopsrg/storageaccount)
+        It "Storage Account directory should exist" {
+            Test-Path -Path $script:storageAccountDirectory | Should -BeTrue
+        }
+        It "Storage Account file should exist" {
+            Test-Path -Path $script:storageAccountFile | Should -BeTrue
+        }
+        It "Storage Account resource type should exist" {
+            $fileContents = Get-Content -Path $script:storageAccountFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -BeTrue
+        }
+        It "Storage Account resource name should exist" {
+            $fileContents = Get-Content -Path $script:storageAccountFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].name | Should -BeTrue
+        }
+        It "Storage Account resource apiVersion should exist" {
+            $fileContents = Get-Content -Path $script:storageAccountFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].apiVersion | Should -BeTrue
+        }
+        It "Storage Account resource properties should exist" {
+            $fileContents = Get-Content -Path $script:storageAccountFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].properties | Should -BeTrue
+        }
+        It "Storage Account resource type should match" {
+            $fileContents = Get-Content -Path $script:storageAccountFile -Raw | ConvertFrom-Json -Depth 25
+            $fileContents.resources[0].type | Should -Be "Microsoft.Storage/storageAccounts"
+        }
+        It "Storage Account deployment should be successful" {
+            $script:storageAccountDeployment = Get-AzResourceGroupDeployment -ResourceGroupName $script:resourceGroup.ResourceGroupName -Name $script:storageAccountDeploymentName
+            $storageAccountDeployment.ProvisioningState | Should -Be "Succeeded"
+        }
+        #endregion
+    }
+
+    AfterAll {
+
+    }
+
+}

--- a/src/tests/subscriptiononly/SubOnly.Tests.ps1
+++ b/src/tests/subscriptiononly/SubOnly.Tests.ps1
@@ -102,7 +102,7 @@ Describe "SubscriptionOnly" {
         }
         #endregion GeneratedRoot Pull
 
-        # The following values are discovering the file system paths so that they can be validate, ensuring that the data model behaves as intended.
+        # The following values are discovering the file system paths, ensuring that the model behaves as intended.
 
         #region Paths
         Write-PSFMessage -Level Debug -Message "GeneratedRootPath: $generatedRoot" -FunctionName "BeforeAll"

--- a/src/tests/templates/rgsubonlydeploy.bicep
+++ b/src/tests/templates/rgsubonlydeploy.bicep
@@ -1,0 +1,11 @@
+targetScope = 'subscription'
+
+param resourceGroupName string
+param location string
+
+resource myRg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: resourceGroupName
+  location: location
+  tags: {}
+  properties: {}
+}

--- a/src/tests/templates/rgsubonlydeploy.parameters.json
+++ b/src/tests/templates/rgsubonlydeploy.parameters.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceGroupName": {
+            "value": "TestSubOnly-azopsrg"
+        },
+        "location": {
+            "value": "northeurope"
+        }
+    }
+}

--- a/src/tests/templates/stasubonlydeploy.bicep
+++ b/src/tests/templates/stasubonlydeploy.bicep
@@ -1,0 +1,19 @@
+param staName string = 'staazops${uniqueString(resourceGroup().id)}'
+param location string = resourceGroup().location
+
+resource storage_resource 'Microsoft.Storage/storageAccounts@2021-08-01' = {
+  name: staName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      bypass: 'None'
+      defaultAction: 'Deny'
+    }
+    supportsHttpsTrafficOnly: true
+  }
+}


### PR DESCRIPTION
# Overview/Summary

This PR fixes #775 by modifying logic to manage **Subscription Only Discovery**, this was regressed in `2.0.0` affecting deployment of objects at and below Subscription scope.

The PR also contains expanded automated testing that adds another GitHub Action Job to catch similar regressions moving forward.

## This PR fixes/adds/changes/removes

1. Changes `tests.yml`
2. Changes `Remove-AzOpsTestsDeployment.ps1`
3. Adds `Microsoft.Subscription/subscriptions.template.jq`
4. Changes `Invoke-AzOpsPull.ps1`
5. Changes `ConvertTo-AzOpsState.ps1`
6. Changes `Pester.ps1`
7. Changes `Repository.Tests.ps1`
8. Adds `SubOnly.Tests.ps1`
9. Adds `rgsubonlydeploy.bicep`
10. Adds `rgsubonlydeploy.parameters.json`
11. Adds `stasubonlydeploy.bicep`

### Breaking Changes

N/A

## Testing Evidence

Testing has been performed in test environment, for future PR's its included in automated pr validation.
![image](https://user-images.githubusercontent.com/64077181/225391377-6266ff0d-cc70-4a41-8019-377253beba24.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
