### PR TITLE
Remove property definitionVersion from policySetDefinitions

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.jq
@@ -1,2 +1,2 @@
 if .identity.userAssignedIdentities != null then del(.identity.userAssignedIdentities[].principalId, .identity.userAssignedIdentities[].clientId, .identity.tenantId, .identity.principalId) else . end |
-del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy)
+del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy)

--- a/src/data/template/Microsoft.Authorization/policyDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policyDefinitions.jq
@@ -1,1 +1,1 @@
-del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy)
+del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.updatedBy)

--- a/src/data/template/Microsoft.Authorization/policyExemptions.jq
+++ b/src/data/template/Microsoft.Authorization/policyExemptions.jq
@@ -1,1 +1,1 @@
-del(.ResourceId, .ResourceGroupName, .SubscriptionId, .SystemData, .Properties.CreatedOn, .Properties.UpdatedOn, .Properties.CreatedBy, .Properties.CreatedBy, .Properties.UpdatedBy)
+del(.ResourceId, .ResourceGroupName, .SubscriptionId, .SystemData, .Properties.CreatedOn, .Properties.UpdatedOn, .Properties.CreatedBy, .Properties.UpdatedBy)

--- a/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
@@ -1,1 +1,1 @@
-del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy)
+del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.policyDefinitions[].definitionVersion, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.updatedBy)

--- a/src/data/template/Microsoft.Authorization/roleAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/roleAssignments.jq
@@ -1,1 +1,1 @@
-del(.properties.createdOn, .properties.updatedOn, .properties.createdBy, .properties.createdBy, .properties.updatedBy)
+del(.properties.createdOn, .properties.updatedOn, .properties.createdBy, .properties.updatedBy)

--- a/src/data/template/Microsoft.Authorization/roleDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/roleDefinitions.jq
@@ -1,1 +1,1 @@
-del(.properties.createdOn, .properties.updatedOn, .properties.createdBy, .properties.createdBy, .properties.updatedBy)
+del(.properties.createdOn, .properties.updatedOn, .properties.createdBy, .properties.updatedBy)


### PR DESCRIPTION
# Overview/Summary

This PR fixes #780 by removing `definitionVersion` property from `policySetDefinitions`. It also cleans up some jq duplication of `properties.createdBy`.

## This PR fixes/adds/changes/removes

1. Changes `Microsoft.Authorization/policyAssignments.jq`
2. Changes `Microsoft.Authorization/policyDefinitions.jq`
3. Changes `Microsoft.Authorization/policyExemptions.jq`
4. Changes `Microsoft.Authorization/policySetDefinitions.jq`
5. Changes `Microsoft.Authorization/roleAssignments.jq`
6. Changes `Microsoft.Authorization/roleDefinitions.jq`

### Breaking Changes

N/A

## Testing Evidence

Tested by running integrations tests, all 157 green.

Jq logic update of `policySetDefinition` example:
![image](https://user-images.githubusercontent.com/64077181/225914808-4ff2700d-faaa-4b8d-bcdf-bb3cde561b2a.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
