### PR TITLE
Adding support for cross tenant template deployment

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.jq
@@ -1,1 +1,0 @@
-del(.ResourceId, .resourceGroup, .subscriptionId, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy, .properties.metadata.assignedBy)

--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -1,0 +1,50 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {
+        "scope": {
+            "type": "string",
+            "defaultValue": .properties.scope
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": .location
+        },
+        "enforcementMode": {
+            "type": "string",
+            "defaultValue": .properties.enforcementMode
+        },
+        "policyparameters": {
+            "type": "object",
+            "defaultValue": .properties.parameters
+        },
+        "identity": {
+            "type": "object",
+            "defaultValue": ( if (.identity.type == "UserAssigned") then { type: .identity.type, userAssignedIdentities : { (.identity.userAssignedIdentities | to_entries[] | .key) : {} } } else { type: .identity.type , principalId:.identity.principalId, tenantId:.identity.tenantId } end)
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": .Type,
+            "name": .name,
+            "apiVersion": "2022-06-01",
+            "location": "[parameters('location')]",
+            "identity": "[if(empty(parameters('identity').type), null(), parameters('identity'))]",
+            "properties": {
+                "description": .properties.description,
+                "displayName":  .properties.displayName,
+                "enforcementMode": "[parameters('enforcementMode')]",
+                "policyDefinitionId": .properties.policyDefinitionId,
+                "scope": "[parameters('scope')]",
+                "parameters": "[parameters('policyparameters')]"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyAssignments.template.jq
@@ -34,6 +34,7 @@
             "type": .Type,
             "name": .name,
             "apiVersion": "2022-06-01",
+            "scope": "[parameters('scope')]",
             "location": "[parameters('location')]",
             "identity": "[if(empty(parameters('identity').type), null(), parameters('identity'))]",
             "properties": {
@@ -41,7 +42,6 @@
                 "displayName":  .properties.displayName,
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "policyDefinitionId": .properties.policyDefinitionId,
-                "scope": "[parameters('scope')]",
                 "parameters": "[parameters('policyparameters')]"
             }
         }

--- a/src/data/template/Microsoft.Authorization/policyDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policyDefinitions.jq
@@ -1,1 +1,0 @@
-del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy)

--- a/src/data/template/Microsoft.Authorization/policyDefinitions.template.jq
+++ b/src/data/template/Microsoft.Authorization/policyDefinitions.template.jq
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "type": .Type,
+            "name": .name,
+            "apiVersion": "2021-06-01",
+            "properties": {
+                "description": .properties.description,
+                "displayName":  .properties.displayName,
+                "metadata": {
+                    "version": .properties.metadata.version,
+                    "category": .properties.metadata.category
+                },
+                "mode": .properties.mode,
+                "parameters": .properties.parameters,
+                "policyRule": .properties.policyRule | walk(if type == "string" and (.|startswith("[")) then "[" + sub("^\\["; "[") else . end),
+                "policyType": .properties.policyType
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
@@ -1,1 +1,0 @@
-del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.createdBy, .properties.metadata.updatedBy)

--- a/src/data/template/Microsoft.Authorization/policySetDefinitions.template.jq
+++ b/src/data/template/Microsoft.Authorization/policySetDefinitions.template.jq
@@ -1,0 +1,31 @@
+del(.properties.policyDefinitions[].definitionVersion, .properties.policyDefinitions[].effectiveDefinitionVersion, .properties.policyDefinitions[].latestDefinitionVersion) |
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "type": .ResourceType,
+            "name": .name,
+            "apiVersion": "2021-06-01",
+            "properties": {
+                "description": .properties.description,
+                "displayName":  .properties.displayName,
+                "metadata": {
+                    "version": .properties.metadata.version,
+                    "category": .properties.metadata.category
+                },
+                "parameters": .properties.parameters,
+                "policyDefinitionGroups" : .properties.policyDefinitionGroups,
+                "policyDefinitions": .properties.policyDefinitions | walk(if type == "string" and (.|startswith("[")) then "[" + sub("^\\["; "[") else . end)
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/src/data/template/Microsoft.Authorization/roleAssignments.jq
+++ b/src/data/template/Microsoft.Authorization/roleAssignments.jq
@@ -1,1 +1,0 @@
-del(.properties.createdOn, .properties.updatedOn, .properties.createdBy, .properties.createdBy, .properties.updatedBy)

--- a/src/data/template/Microsoft.Authorization/roleAssignments.template.jq
+++ b/src/data/template/Microsoft.Authorization/roleAssignments.template.jq
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+      "name": {
+          "type": "string",
+          "defaultValue": .name
+      },
+      "principalId": {
+          "type": "string",
+          "defaultValue": .properties.principalId
+      },
+      "principalType": {
+          "type": "string",
+          "defaultValue": .properties.principalType
+      },
+      "roleDefinitionId": {
+          "type": "string",
+          "defaultValue": .properties.roleDefinitionId
+      },
+      "scope": {
+          "type": "string",
+          "defaultValue": .properties.scope
+      }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "name": "[parameters('name')]",
+      "apiVersion": "2022-04-01",
+      "properties": {
+        "principalId": "[parameters('principalId')]",
+        "principalType": "[parameters('principalType')]",
+        "roleDefinitionId": "[parameters('roleDefinitionId')]",
+        "scope": "[parameters('scope')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.ManagedIdentity/userAssignedIdentities.template.jq
+++ b/src/data/template/Microsoft.ManagedIdentity/userAssignedIdentities.template.jq
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "_generator": {
+            "name": "AzOps"
+        }
+    },
+    "parameters": {},
+    "variables": {},
+    "resources": [
+        {
+            "type": .Type,
+            "name": .name,
+            "apiVersion": "2023-01-31",
+            "location":.location
+        }
+    ],
+    "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/azureFirewalls.template.jq
+++ b/src/data/template/Microsoft.Network/azureFirewalls.template.jq
@@ -1,0 +1,43 @@
+del(.properties.ipConfigurations[].etag, .properties.ipConfigurations[].id, .properties.ipConfigurations[].properties.provisioningState) |
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "firewallPolicy": {
+        "type": "object",
+        "defaultValue": .properties.firewallPolicy
+    },
+    "ipConfigurations": {
+        "type": "array",
+        "defaultValue": .properties.ipConfigurations
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/azureFirewalls",
+      "name": "gs-co-fw-eastus",
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "additionalProperties": .properties.additionalProperties,
+        "applicationRuleCollections": .properties.applicationRuleCollections,
+        "firewallPolicy":  "[parameters('firewallPolicy')]",
+        "ipConfigurations": "[parameters('ipConfigurations')]",
+        "natRuleCollections": .properties.natRuleCollections,
+        "networkRuleCollections": .properties.networkRuleCollections,
+        "sku": {
+          "name": "AZFW_VNet",
+          "tier": "Standard"
+        },
+        "threatIntelMode": "Alert"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/ddosProtectionPlans.template.jq
+++ b/src/data/template/Microsoft.Network/ddosProtectionPlans.template.jq
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "virtualNetworks": {
+          "type": "array",
+          "defaultValue": .properties.virtualNetworks
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/ddosProtectionPlans",
+      "name": "gs-co-ddos-eastus",
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "virtualNetworks": "[parameters('virtualNetworks')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/dnsResolvers.template.jq
+++ b/src/data/template/Microsoft.Network/dnsResolvers.template.jq
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "virtualNetwork": {
+      "type": "object",
+      "defaultValue": .properties.virtualNetwork
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/dnsResolvers",
+      "name": .name,
+      "apiVersion": "2022-07-01",
+      "location": .location,
+      "properties": {
+        "virtualNetwork": "[parameters('virtualNetwork')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/dnsResolvers/inboundendpoints.template.jq
+++ b/src/data/template/Microsoft.Network/dnsResolvers/inboundendpoints.template.jq
@@ -7,9 +7,9 @@
     }
   },
   "parameters": {
-    "virtualNetwork": {
-       "type": "object",
-       "defaultValue": .properties.virtualNetwork
+    "ipConfigurations": {
+        "type": "array",
+        "defaultValue": .properties.ipConfigurations
     },
     "resourceId": {
        "type": "string",
@@ -21,13 +21,12 @@
   },
   "resources": [
     {
-      "type": "Microsoft.Network/privateDnsZones/virtualnetworklinks",
+      "type": "Microsoft.Network/dnsResolvers/inboundendpoints",
       "name": "[variables('name')]",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "location": .location,
       "properties": {
-        "registrationEnabled": false,
-        "virtualNetwork": "[parameters('virtualNetwork')]"
+        "ipConfigurations": "[parameters('ipConfigurations')]"
       }
     }
   ],

--- a/src/data/template/Microsoft.Network/dnsResolvers/outboundendpoints.template.jq
+++ b/src/data/template/Microsoft.Network/dnsResolvers/outboundendpoints.template.jq
@@ -7,9 +7,9 @@
     }
   },
   "parameters": {
-    "virtualNetwork": {
-       "type": "object",
-       "defaultValue": .properties.virtualNetwork
+    "subnet": {
+        "type": "object",
+        "defaultValue": .properties.subnet
     },
     "resourceId": {
        "type": "string",
@@ -21,13 +21,12 @@
   },
   "resources": [
     {
-      "type": "Microsoft.Network/privateDnsZones/virtualnetworklinks",
+      "type": "Microsoft.Network/dnsResolvers/outboundendpoints",
       "name": "[variables('name')]",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "location": .location,
       "properties": {
-        "registrationEnabled": false,
-        "virtualNetwork": "[parameters('virtualNetwork')]"
+        "subnet": "[parameters('subnet')]"
       }
     }
   ],

--- a/src/data/template/Microsoft.Network/firewallPolicies.template.jq
+++ b/src/data/template/Microsoft.Network/firewallPolicies.template.jq
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "firewalls": {
+        "type": "array",
+        "defaultValue": .properties.firewalls
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/firewallPolicies",
+      "name": .name,
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "childPolicies": [],
+        "firewalls": "[parameters('firewalls')]",
+        "ruleCollectionGroups": [],
+        "sku": {
+          "tier": "Standard"
+        },
+        "threatIntelMode": "Alert"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/networkSecurityGroups.template.jq
+++ b/src/data/template/Microsoft.Network/networkSecurityGroups.template.jq
@@ -1,0 +1,31 @@
+del(.properties.defaultSecurityRules[].etag, .properties.defaultSecurityRules[].id) |
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "subnets": {
+        "type": "array",
+        "defaultValue": .properties.subnets
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": .name,
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "defaultSecurityRules": .properties.defaultSecurityRules,
+        "securityRules": .properties.securityRules,
+        "subnets": "[parameters('subnets')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/privateDnsZones.template.jq
+++ b/src/data/template/Microsoft.Network/privateDnsZones.template.jq
@@ -1,0 +1,22 @@
+del(.properties.internalId,.properties.numberOfRecordSets,.properties.numberOfVirtualNetworkLinks,.properties.numberOfVirtualNetworkLinksWithRegistration) |
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {},
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/privateDnsZones",
+      "name": .name,
+      "apiVersion": "2020-06-01",
+      "location": .location,
+      "properties": .properties
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/privateDnsZones/virtualnetworklinks.template.jq
+++ b/src/data/template/Microsoft.Network/privateDnsZones/virtualnetworklinks.template.jq
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "virtualNetwork": {
+       "type": "object",
+       "defaultValue": .properties.virtualNetwork
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualnetworklinks",
+      "name": .name,
+      "apiVersion": "2020-06-01",
+      "location": .location,
+      "properties": {
+        "registrationEnabled": false,
+        "virtualNetwork": "[parameters('virtualNetwork')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/publicIPAddresses.template.jq
+++ b/src/data/template/Microsoft.Network/publicIPAddresses.template.jq
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "ipAddress": {
+        "type": "string",
+        "defaultValue": .properties.ipAddress
+    },
+    "ipConfiguration": {
+        "type": "object",
+        "defaultValue": .properties.ipConfiguration
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": .name,
+      "sku": {
+        "name": "Standard",
+        "tier": "Regional"
+      },
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "idleTimeoutInMinutes": 4,
+        "ipAddress": "[parameters('ipAddress')]",
+        "ipConfiguration":"[parameters('ipConfiguration')]",
+        "ipTags": [],
+        "publicIPAddressVersion": .properties.publicIPAddressVersion,
+        "publicIPAllocationMethod": .properties.publicIPAllocationMethod
+      },
+      "zones": [
+        "1",
+        "2",
+        "3"
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/routeTables.template.jq
+++ b/src/data/template/Microsoft.Network/routeTables.template.jq
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "subnets": {
+        "type": "array",
+        "defaultValue": .properties.subnets
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/routeTables",
+      "name": .name,
+      "apiVersion": "2022-11-01",
+      "location": .location,
+      "properties": {
+        "disableBgpRoutePropagation": false,
+        "routes": [],
+        "subnets": "[parameters('subnets')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.Network/virtualnetworks.jq
+++ b/src/data/template/Microsoft.Network/virtualnetworks.jq
@@ -1,1 +1,1 @@
-del(.. | .resourceGuid?, .resourceId?, .identity?, .kind?, .resourceName?, .extensionResourceName?, .parentResource?, .plan?, .etag? , .provisioningState?)
+del(.. | .resourceGuid?, .resourceId?, .identity?, .kind?, .resourceName?, .extensionResourceName?, .parentResource?, .plan?, .etag? , .provisioningState?) | del (.properties.subnets[].id)

--- a/src/data/template/Microsoft.OperationalInsights/workspaces.template.jq
+++ b/src/data/template/Microsoft.OperationalInsights/workspaces.template.jq
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+    "name": {
+        "type": "string",
+        "defaultValue": .name
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "name": "[parameters('name')]",
+      "apiVersion": "2022-10-01",
+      "location": .location,
+      "properties": {
+        "retentionInDays": 30,
+        "sku": {
+          "name": "pergb2018"
+        },
+        "enableLogAccessUsingOnlyResourcePermissions": true
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.OperationsManagement/solutions.template.jq
+++ b/src/data/template/Microsoft.OperationsManagement/solutions.template.jq
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "AzOps"
+    }
+  },
+  "parameters": {
+      "containedResources": {
+          "type": "array",
+          "defaultValue": .properties.containedResources
+      },
+      "workspaceResourceId": {
+          "type": "string",
+          "defaultValue": .properties.workspaceResourceId
+      },
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.OperationsManagement/solutions",
+      "name": .name,
+      "apiVersion": "2015-11-01-preview",
+      "location": .location,
+      "properties": {
+        "containedResources": "[parameters('containedResources')]",
+        "workbookTemplates": [],
+        "workspaceResourceId": "[parameters('workspaceResourceId')]"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/src/data/template/Microsoft.OperationsManagement/solutions.template.jq
+++ b/src/data/template/Microsoft.OperationsManagement/solutions.template.jq
@@ -23,6 +23,7 @@
       "name": .name,
       "apiVersion": "2015-11-01-preview",
       "location": .location,
+      "plan": .plan,
       "properties": {
         "containedResources": "[parameters('containedResources')]",
         "workbookTemplates": [],

--- a/src/internal/classes/AzOpsScope.ps1
+++ b/src/internal/classes/AzOpsScope.ps1
@@ -283,14 +283,7 @@
             $this.ResourceGroup = $this.GetResourceGroup()
             $this.ResourceProvider = $this.IsResourceProvider()
             $this.Resource = $this.GetResource()
-            if ( (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix') -notcontains 'parameters.json' -and
-                ("$($this.ResourceProvider)/$($this.Resource)" -in 'Microsoft.Authorization/policyDefinitions', 'Microsoft.Authorization/policySetDefinitions')
-            ) {
-                $this.StatePath = ($this.GetAzOpsResourcePath() + '.parameters' + (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'))
-            }
-            else {
-                $this.StatePath = ($this.GetAzOpsResourcePath() + (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'))
-            }
+            $this.StatePath = ($this.GetAzOpsResourcePath() + (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'))
         }
         elseif ($this.IsResourceGroup()) {
             $this.Type = "resourcegroups"

--- a/src/internal/functions/ConvertTo-AzOpsState.ps1
+++ b/src/internal/functions/ConvertTo-AzOpsState.ps1
@@ -219,21 +219,26 @@
                     #endregion
 
                     #region Replace Resource Type and API Version
-                    if (
-                        ($Script:AzOpsResourceProvider | Where-Object { $_.ProviderNamespace -eq $providerNamespace }) -and
+                    if ($object.resources[0].apiVersion -ne "0000-00-00")
+                    {
+                        if(($Script:AzOpsResourceProvider | Where-Object { $_.ProviderNamespace -eq $providerNamespace }) -and
                         (($Script:AzOpsResourceProvider | Where-Object { $_.ProviderNamespace -eq $providerNamespace }).ResourceTypes | Where-Object { $_.ResourceTypeName -eq $resourceApiTypeName })
-                    ) {
-                        $apiVersions = (($Script:AzOpsResourceProvider | Where-Object { $_.ProviderNamespace -eq $providerNamespace }).ResourceTypes | Where-Object { $_.ResourceTypeName -eq $resourceApiTypeName }).ApiVersions[0]
-                        Write-PSFMessage -Level Verbose -String 'ConvertTo-AzOpsState.GenerateTemplate.ApiVersion' -StringValues $resourceType, $apiVersions -FunctionName 'ConvertTo-AzOpsState'
+                         ) {
+                            $apiVersions = (($Script:AzOpsResourceProvider | Where-Object { $_.ProviderNamespace -eq $providerNamespace }).ResourceTypes | Where-Object { $_.ResourceTypeName -eq $resourceApiTypeName }).ApiVersions[0]
+                            Write-PSFMessage -Level Verbose -String 'ConvertTo-AzOpsState.GenerateTemplate.ApiVersion' -StringValues $resourceType, $apiVersions -FunctionName 'ConvertTo-AzOpsState'
 
-                        $object.resources[0].apiVersion = $apiVersions
-                        $object.resources[0].type = $resourceType
+                            $object.resources[0].apiVersion = $apiVersions
+                            $object.resources[0].type = $resourceType
+                        }
+                        else {
+                            Write-PSFMessage -Level Verbose -String 'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersion' -StringValues $resourceType -FunctionName 'ConvertTo-AzOpsState'
+                        }
+                        #endregion
                     }
                     else {
-                        Write-PSFMessage -Level Warning -String 'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersion' -StringValues $resourceType -FunctionName 'ConvertTo-AzOpsState'
+                        #No need to retrive the API version dynamically
+                        Write-PSFMessage -Level Warning -String 'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersionRequired' -StringValues $resourceType -FunctionName 'ConvertTo-AzOpsState'
                     }
-                    #endregion
-
                     #region Append Name for child resource
                     # [Patch] Temporary until mangementGroup() is fully implemented
                     if ($resourceType -eq "Microsoft.Management/managementGroups/subscriptions") {

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -68,6 +68,7 @@
     'ConvertTo-AzOpsState.GenerateTemplate.ResourceApiTypeName'                     = 'Resource api type: {0}' # $resourceApiTypeName
     'ConvertTo-AzOpsState.GenerateTemplate.ApiVersion'                              = 'Determined api version: {1} for resource type name: {0}' # $resourceType, $apiVersions
     'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersion'                            = 'Unable to determine api version from resource type name: {0}' # $resourceTypeName
+    'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersionRequired'                    = 'Template already contains api version from resource type name: {0}' # $resourceTypeName
     'ConvertTo-AzOpsState.GenerateTemplate.ChildResource'                           = 'Appending child resource name: {0}' # $resourceName
     'ConvertTo-AzOpsState.ObjectType.Resolved.Generic'                              = 'Unable to determine object type: {0}' # $($_.GetType())
     'ConvertTo-AzOpsState.ObjectType.Resolved.PSObject'                             = 'Determined object type based on PowerShell class {0}' # $($_.GetType())


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Templates crafted by AzOps have tenant specific values embedded inside the property bag. By parameterising these tenant specific values in to parameter section of the templates, it will allow templates to be targeted to different tenants if needed.

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

#776 

### Breaking Changes

Change in data model as we will generate policy and policyset as native ARM Template vs Parameter file.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
