### PR TITLE
Silence output from Set-AzOpsContext

### DIFF
--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -100,7 +100,7 @@
         # Resource Groups excluding Microsoft.Resources/resourceGroups that needs to be submitted at subscription scope
         if ($scopeObject.resourcegroup -and $templateContent.resources[0].type -ne 'Microsoft.Resources/resourceGroups') {
             Write-AzOpsMessage -LogLevel Verbose -LogString 'New-AzOpsDeployment.ResourceGroup.Processing' -LogStringValues $scopeObject -Target $scopeObject
-            $null = Set-AzOpsContext -ScopeObject $scopeObject
+            Set-AzOpsContext -ScopeObject $scopeObject
             $whatIfCommand = 'Get-AzResourceGroupDeploymentWhatIfResult'
             $deploymentCommand = 'New-AzResourceGroupDeployment'
             $parameters.ResourceGroupName = $scopeObject.resourcegroup
@@ -109,7 +109,7 @@
         # Subscriptions
         elseif ($scopeObject.subscription) {
             Write-AzOpsMessage -LogLevel Verbose -LogString 'New-AzOpsDeployment.Subscription.Processing' -LogStringValues $defaultDeploymentRegion, $scopeObject -Target $scopeObject
-            $null = Set-AzOpsContext -ScopeObject $scopeObject
+            Set-AzOpsContext -ScopeObject $scopeObject
             $whatIfCommand = 'Get-AzSubscriptionDeploymentWhatIfResult'
             $deploymentCommand = 'New-AzSubscriptionDeployment'
         }

--- a/src/internal/functions/New-AzOpsDeployment.ps1
+++ b/src/internal/functions/New-AzOpsDeployment.ps1
@@ -100,7 +100,7 @@
         # Resource Groups excluding Microsoft.Resources/resourceGroups that needs to be submitted at subscription scope
         if ($scopeObject.resourcegroup -and $templateContent.resources[0].type -ne 'Microsoft.Resources/resourceGroups') {
             Write-AzOpsMessage -LogLevel Verbose -LogString 'New-AzOpsDeployment.ResourceGroup.Processing' -LogStringValues $scopeObject -Target $scopeObject
-            Set-AzOpsContext -ScopeObject $scopeObject
+            $null = Set-AzOpsContext -ScopeObject $scopeObject
             $whatIfCommand = 'Get-AzResourceGroupDeploymentWhatIfResult'
             $deploymentCommand = 'New-AzResourceGroupDeployment'
             $parameters.ResourceGroupName = $scopeObject.resourcegroup
@@ -109,7 +109,7 @@
         # Subscriptions
         elseif ($scopeObject.subscription) {
             Write-AzOpsMessage -LogLevel Verbose -LogString 'New-AzOpsDeployment.Subscription.Processing' -LogStringValues $defaultDeploymentRegion, $scopeObject -Target $scopeObject
-            Set-AzOpsContext -ScopeObject $scopeObject
+            $null = Set-AzOpsContext -ScopeObject $scopeObject
             $whatIfCommand = 'Get-AzSubscriptionDeploymentWhatIfResult'
             $deploymentCommand = 'New-AzSubscriptionDeployment'
         }

--- a/src/internal/functions/Set-AzOpsContext.ps1
+++ b/src/internal/functions/Set-AzOpsContext.ps1
@@ -26,7 +26,7 @@
         if (-not $ScopeObject.Subscription) { return }
         if ($context.Subscription.Id -ne $ScopeObject.Subscription) {
             Write-AzOpsMessage -LogLevel InternalComment -LogString 'Set-AzOpsContext.Change' -LogStringValues $context.Subscription.Name, $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
-            Set-AzContext -SubscriptionId $scopeObject.Subscription -WhatIf:$false
+            $null = Set-AzContext -SubscriptionId $scopeObject.Subscription -WhatIf:$false
         }
     }
 }

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -1144,7 +1144,7 @@ Describe "Repository" {
             $diff3 = New-TimeSpan -Start $createTime.changeTime[1] -End $createTime.changeTime[2]
             $diff4 = New-TimeSpan -Start $createTime.changeTime[0] -End $createTime.changeTime[3]
             # Check if time difference is within x seconds
-            $allowedDiff = '8'
+            $allowedDiff = '15'
             if ($diff1.TotalSeconds -le $allowedDiff -and $diff2.TotalSeconds -le $allowedDiff -and $diff3.TotalSeconds -le $allowedDiff -and $diff4.TotalSeconds -ge $allowedDiff) {
                 # Time difference is within x seconds of each other
                 $timeTest = "good"

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -1144,7 +1144,7 @@ Describe "Repository" {
             $diff3 = New-TimeSpan -Start $createTime.changeTime[1] -End $createTime.changeTime[2]
             $diff4 = New-TimeSpan -Start $createTime.changeTime[0] -End $createTime.changeTime[3]
             # Check if time difference is within x seconds
-            $allowedDiff = '15'
+            $allowedDiff = '25'
             if ($diff1.TotalSeconds -le $allowedDiff -and $diff2.TotalSeconds -le $allowedDiff -and $diff3.TotalSeconds -le $allowedDiff -and $diff4.TotalSeconds -ge $allowedDiff) {
                 # Time difference is within x seconds of each other
                 $timeTest = "good"


### PR DESCRIPTION
Suggested fix for #853 

This PR makes sure no output is caught from `Set-AzContext`.