### PR TITLE
Fix jq version evaluation

### DIFF
--- a/scripts/UpdateRequiredModules.ps1
+++ b/scripts/UpdateRequiredModules.ps1
@@ -4,11 +4,9 @@ $existingmodule = @()
 $newmodule = @()
 $updated = $false
 $data.RequiredModules | ForEach-Object {
-    $moduleVersion = $_.RequiredVersion
-    [int]$moduleVersionInt = $moduleVersion.Replace('.',',')
-    $galleryVersion = (Find-Module -Name $_.ModuleName).Version
-    [int]$galleryVersionInt = $galleryVersion.Replace('.',',')
-    if ($moduleVersionInt -lt $galleryVersionInt) {
+    $moduleVersion = New-Object System.Version($_.RequiredVersion)
+    $galleryVersion = New-Object System.Version((Find-Module -Name $_.ModuleName).Version)
+    if ($moduleVersion -lt $galleryVersion) {
         $newmodule = @{
             "ModuleName" = $_.ModuleName
             "RequiredVersion" = $galleryVersion

--- a/src/internal/functions/Assert-AzOpsJqDependency.ps1
+++ b/src/internal/functions/Assert-AzOpsJqDependency.ps1
@@ -19,13 +19,13 @@
 
     process {
         Write-AzOpsMessage -LogLevel InternalComment -LogString 'Assert-AzOpsJqDependency.Validating'
-
+        $minVersion = New-Object System.Version("1.6")
         $result = (Invoke-AzOpsNativeCommand -ScriptBlock { jq --version } -IgnoreExitcode)
         $installed = $result -as [bool]
 
         if ($installed) {
-            [double]$version = ($result).Split("-")[1]
-            if ($version -ge 1.6) {
+            $version = New-Object System.Version(($result).Split("-")[1])
+            if ($version -ge $minVersion) {
                 Write-AzOpsMessage -LogLevel InternalComment -LogString 'Assert-AzOpsJqDependency.Success'
                 return
             }

--- a/src/tests/functional/Microsoft.Network/connections/deploy/deploy.json
+++ b/src/tests/functional/Microsoft.Network/connections/deploy/deploy.json
@@ -40,7 +40,7 @@
             "name": "[parameters('publicIPAddressesName')]",
             "location": "northeurope",
             "sku": {
-                "name": "Basic",
+                "name": "Standard",
                 "tier": "Regional"
             },
             "properties": {

--- a/src/tests/functional/Microsoft.Network/connections/deploy/deploy.json
+++ b/src/tests/functional/Microsoft.Network/connections/deploy/deploy.json
@@ -46,7 +46,7 @@
             "properties": {
                 "ipAddress": "20.219.217.108",
                 "publicIPAddressVersion": "IPv4",
-                "publicIPAllocationMethod": "Dynamic",
+                "publicIPAllocationMethod": "Static",
                 "idleTimeoutInMinutes": 4,
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('publicIPAddressesName')]",


### PR DESCRIPTION
# Overview/Summary

This PR closes #865 by changing the logic used to determine jq --version output.

## This PR fixes/adds/changes/removes

1. Changes Assert-AzOpsJqDependency.ps1

### Breaking Changes

1. N/A

## Testing Evidence

Testing with a jq version variable set to 1.7.1 evaluates correct.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
