### PR TITLE
Load Template Content for Push Deployment in-memory

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -462,7 +462,11 @@
         #Starting deployment
         $WhatIfPreference = $WhatIfPreferenceState
         $uniqueProperties = 'Scope', 'DeploymentName', 'TemplateFilePath', 'TemplateParameterFilePath'
-        $uniqueDeployment = $deploymentList | Select-Object $uniqueProperties -Unique
+        $uniqueDeployment = $deploymentList | Select-Object $uniqueProperties -Unique | ForEach-Object {
+            $TemplateFileContent = [System.IO.File]::ReadAllText($_.TemplateFilePath)
+            $TemplateObject = ConvertFrom-Json $TemplateFileContent -AsHashtable
+            $_ | Add-Member -MemberType NoteProperty -Name 'TemplateObject' -Value $TemplateObject -PassThru
+        }
         $deploymentResult = @()
 
         if ($uniqueDeployment) {


### PR DESCRIPTION
# Overview/Summary

This PR changes how AzOps utilizes the template file during deployment and fixes #868.

**New behavior:**
New-AzOpsDeployment will first attempt to utilize a parameter $TemplateObject that contains the relevant template content as a hashtable. Only if this parameter $TemplateObject is missing will it attempt to read the template file content.

**Current behavior:**
New-AzOpsDeployment attempt to read the content of the template file and potentially lock it during read and deployment.



## This PR fixes/adds/changes/removes

1. Changes `Invoke-AzOpsPush.ps1`
2. Changes `New-AzOpsDeployment.ps1`

### Breaking Changes

1. N/A

## Testing Evidence

Tests have been performed that locks the template files destined for deployment prior to `Invoke-AzOpsPush` calls `New-AzOpsDeployment` and with this code change the module continues to execute successful deployments. Without the code change it fails due to file lock.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.