### PR TITLE
Fix Jq filter to allow empty defaultValue for policy definition and set definition

### DIFF
--- a/src/data/template/Microsoft.Authorization/policyDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policyDefinitions.jq
@@ -1,2 +1,8 @@
 del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.updatedBy)
-| walk(if type == "object" then with_entries(if .key == "equals" or .key == "notEquals" or .key == "like" or .key == "notLike" or .key == "match" or .key == "matchInsensitively" or .key == "notMatch" or .key == "notMatchInsensitively" or .key == "contains" or .key == "notContains" or .key == "in" or .key == "notIn" or .key == "containsKey" or .key == "notContainsKey" or .key == "less" or .key == "lessOrEquals" or .key == "greater" or .key == "greaterOrEquals" or .key == "exists" then . else select(.value != "") end) else . end)
+| walk(if type == "object" then with_entries(
+      if .key == "equals" or .key == "notEquals" or .key == "like" or .key == "notLike" or .key == "match" or .key == "matchInsensitively" or .key == "notMatch" or .key == "notMatchInsensitively" or .key == "contains" or .key == "notContains" or .key == "in" or .key == "notIn" or .key == "containsKey" or .key == "notContainsKey" or .key == "less" or .key == "lessOrEquals" or .key == "greater" or .key == "greaterOrEquals" or .key == "exists"
+      then .
+      else select(.value != "" or (.key == "defaultValue" and .value == ""))
+      end
+    )
+  else . end)

--- a/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
+++ b/src/data/template/Microsoft.Authorization/policySetDefinitions.jq
@@ -1,2 +1,4 @@
 del(.ResourceId, .id, .tenantId, .subscriptionId, .properties.policyType, .properties.policyDefinitions[].definitionVersion, .properties.metadata.createdOn, .properties.metadata.updatedOn, .properties.metadata.createdBy, .properties.metadata.updatedBy)
-| del(.. | select(. == ""))
+| walk(if type == "object" then with_entries(
+    select(.value != "" or (.key == "defaultValue" and .value == "")))
+    else . end)


### PR DESCRIPTION
# Overview/Summary

This PR fixes #874 by adjusting `policyDefinitions.jq` and `policySetDefinitions.jq` to allow `defaultValue` to be empty.

## This PR fixes/adds/changes/removes

1. Changes `policyDefinitions.jq`
2. Changes `policySetDefinitions.jq`

### Breaking Changes

N/A

## Testing Evidence

Tests have been performed to evaluate if empty `defaultValue` is pulled back and persisted while still removing other unwanted empty key value pairs.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
