### PR TITLE
Fix File Pair Processing of Modify and Deletion Overlap

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -55,8 +55,18 @@
                 [string[]]
                 $ConvertedTemplate,
                 [string[]]
-                $ConvertedParameter
+                $ConvertedParameter,
+                [switch]
+                $CompareDeploymentToDeletion
             )
+
+            # Avoid adding files destined for deletion to a deployment list
+            if ($CompareDeploymentToDeletion) {
+                if ($FilePath -in $deleteSet) {
+                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $FilePath
+                    continue
+                }
+            }
 
             # Avoid duplicate entries in the deployment list
             if ($FilePath.EndsWith(".parameters.json")) {
@@ -72,7 +82,7 @@
 
             # Handle Bicep templates
             if ($FilePath.EndsWith(".bicep")) {
-                $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $FilePath -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter
+                $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $FilePath -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
                 if ($true -eq $transpiledTemplatePaths.transpiledTemplateNew) {
                     $ConvertedTemplate += $transpiledTemplatePaths.transpiledTemplatePath
                 }
@@ -93,7 +103,7 @@
             }
 
             # Resolve ARM file association
-            $resolvedArmFileAssociation = Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $FilePath -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter
+            $resolvedArmFileAssociation = Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $FilePath -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
             if ($resolvedArmFileAssociation) {
                 foreach ($fileAssociation in $resolvedArmFileAssociation) {
                     if ($true -eq $transpiledTemplatePaths.transpiledTemplateNew -and $fileAssociation.TemplateFilePath -eq $transpiledTemplatePaths.transpiledTemplatePath) {
@@ -118,7 +128,9 @@
                 [string[]]
                 $ConvertedTemplate,
                 [string[]]
-                $ConvertedParameter
+                $ConvertedParameter,
+                [switch]
+                $CompareDeploymentToDeletion
             )
 
             #region Initialization Prep
@@ -163,6 +175,13 @@
                             $bicepTemplatePath = $fileItem.FullName -replace '.parameters.json', '.bicep'
                         }
                         if (Test-Path $templatePath) {
+                            if ($CompareDeploymentToDeletion) {
+                                # Avoid adding files destined for deletion to a deployment list
+                                if ($templatePath -in ($deleteSet | Resolve-Path).Path) {
+                                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $templatePath
+                                    return
+                                }
+                            }
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.FoundTemplate' -LogStringValues $FilePath, $templatePath
                             $result.TemplateFilePath = $templatePath
                             $newScopeObject = New-AzOpsScope -Path $result.TemplateFilePath -StatePath $StatePath -ErrorAction Stop
@@ -171,8 +190,15 @@
                             return $result
                         }
                         elseif (Test-Path $bicepTemplatePath) {
+                            if ($CompareDeploymentToDeletion) {
+                                # Avoid adding files destined for deletion to a deployment list
+                                if ($bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
+                                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $bicepTemplatePath
+                                    return
+                                }
+                            }
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.FoundBicepTemplate' -LogStringValues $FilePath, $bicepTemplatePath
-                            $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $bicepTemplatePath -SkipParam -ConvertedTemplate $ConvertedTemplate
+                            $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $bicepTemplatePath -SkipParam -ConvertedTemplate $ConvertedTemplate -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
                             $result.TranspiledTemplateNew = $transpiledTemplatePaths.transpiledTemplateNew
                             $result.TemplateFilePath = $transpiledTemplatePaths.transpiledTemplatePath
                             $newScopeObject = New-AzOpsScope -Path $result.TemplateFilePath -StatePath $StatePath -ErrorAction Stop
@@ -190,8 +216,15 @@
                             $bicepTemplatePath = $fileItem.FullName -replace '\.bicepparam', '.bicep'
                         }
                         if (Test-Path $bicepTemplatePath) {
+                            if ($CompareDeploymentToDeletion) {
+                                # Avoid adding files destined for deletion to a deployment list
+                                if ($bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
+                                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $bicepTemplatePath
+                                    return
+                                }
+                            }
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.FoundBicepTemplate' -LogStringValues $FilePath, $bicepTemplatePath
-                            $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $bicepTemplatePath -BicepParamTemplatePath $fileItem.FullName -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter
+                            $transpiledTemplatePaths = ConvertFrom-AzOpsBicepTemplate -BicepTemplatePath $bicepTemplatePath -BicepParamTemplatePath $fileItem.FullName -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
                             $result.TranspiledTemplateNew = $transpiledTemplatePaths.transpiledTemplateNew
                             $result.TranspiledParametersNew = $transpiledTemplatePaths.transpiledParametersNew
                             $result.TemplateFilePath = $transpiledTemplatePaths.transpiledTemplatePath
@@ -245,8 +278,20 @@
             $result.TemplateFilePath = $fileItem.FullName
             $parameterPath = Join-Path $fileItem.Directory.FullName -ChildPath ($fileItem.BaseName + '.parameters' + (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'))
             if (Test-Path -Path $parameterPath) {
-                Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterFound' -LogStringValues $FilePath, $parameterPath
-                $result.TemplateParameterFilePath = $parameterPath
+                if ($CompareDeploymentToDeletion) {
+                    # Avoid adding files destined for deletion to a deployment list
+                    if ($parameterPath -in ($deleteSet | Resolve-Path).Path) {
+                        Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $parameterPath
+                        $skipParameters = $true
+                    }
+                }
+                else {
+                    $skipParameters = $false
+                }
+                if (-not $skipParameters) {
+                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterFound' -LogStringValues $FilePath, $parameterPath
+                    $result.TemplateParameterFilePath = $parameterPath
+                }
             }
             elseif ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true -and (Get-PSFConfigValue -FullName 'AzOps.Core.DeployAllMultipleTemplateParameterFiles') -eq $true) {
                 # Check for multiple associated template parameter files
@@ -254,10 +299,17 @@
                 if ($paramFileList) {
                     $multiResult = @()
                     foreach ($paramFile in $paramFileList) {
+                        if ($CompareDeploymentToDeletion) {
+                            # Avoid adding files destined for deletion to a deployment list
+                            if ($paramFile.VersionInfo.FileName -in ($deleteSet | Resolve-Path).Path) {
+                                Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $paramFile.VersionInfo.FileName
+                                continue
+                            }
+                        }
                         # Process possible parameter files for template equivalent
                         if (($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-3]) -or ($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-4])) {
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $paramFile.FullName
-                            $multiResult += Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $paramFile -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter
+                            $multiResult += Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $paramFile -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
                         }
                     }
                     if ($multiResult) {
@@ -416,7 +468,7 @@
         #region Create DeploymentList
         $deploymentList = foreach ($addition in $addModifySet | Where-Object { $_ -match ((Get-Item $StatePath).Name) }) {
             # Create a list of deployment file associations using the New-AzOpsList function
-            $deployFileAssociationList = New-AzOpsList -FilePath $addition -FileSet $addModifySet -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $AzOpsTranspiledTemplate -ConvertedParameter $AzOpsTranspiledParameter
+            $deployFileAssociationList = New-AzOpsList -FilePath $addition -FileSet $addModifySet -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $AzOpsTranspiledTemplate -ConvertedParameter $AzOpsTranspiledParameter -CompareDeploymentToDeletion
             # Iterate through each file association in the list
             foreach ($fileAssociation in $deployFileAssociationList) {
                 # Check if the transpiled template is new and add it to the collection if true

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -62,7 +62,7 @@
 
             # Avoid adding files destined for deletion to a deployment list
             if ($CompareDeploymentToDeletion) {
-                if ($FilePath -in $deleteSet) {
+                if ($FilePath -in $deleteSet -or $FilePath -in ($deleteSet | Resolve-Path).Path) {
                     Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $FilePath
                     continue
                 }
@@ -177,7 +177,7 @@
                         if (Test-Path $templatePath) {
                             if ($CompareDeploymentToDeletion) {
                                 # Avoid adding files destined for deletion to a deployment list
-                                if ($templatePath -in ($deleteSet | Resolve-Path).Path) {
+                                if ($templatePath -in $deleteSet -or $templatePath -in ($deleteSet | Resolve-Path).Path) {
                                     Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $templatePath
                                     return
                                 }
@@ -192,7 +192,7 @@
                         elseif (Test-Path $bicepTemplatePath) {
                             if ($CompareDeploymentToDeletion) {
                                 # Avoid adding files destined for deletion to a deployment list
-                                if ($bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
+                                if ($bicepTemplatePath -in $deleteSet -or $bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
                                     Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $bicepTemplatePath
                                     return
                                 }
@@ -218,7 +218,7 @@
                         if (Test-Path $bicepTemplatePath) {
                             if ($CompareDeploymentToDeletion) {
                                 # Avoid adding files destined for deletion to a deployment list
-                                if ($bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
+                                if ($bicepTemplatePath -in $deleteSet -or $bicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
                                     Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $bicepTemplatePath
                                     return
                                 }
@@ -280,7 +280,7 @@
             if (Test-Path -Path $parameterPath) {
                 if ($CompareDeploymentToDeletion) {
                     # Avoid adding files destined for deletion to a deployment list
-                    if ($parameterPath -in ($deleteSet | Resolve-Path).Path) {
+                    if ($parameterPath -in $deleteSet -or $parameterPath -in ($deleteSet | Resolve-Path).Path) {
                         Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $parameterPath
                         $skipParameters = $true
                     }
@@ -301,7 +301,7 @@
                     foreach ($paramFile in $paramFileList) {
                         if ($CompareDeploymentToDeletion) {
                             # Avoid adding files destined for deletion to a deployment list
-                            if ($paramFile.VersionInfo.FileName -in ($deleteSet | Resolve-Path).Path) {
+                            if ($paramFile.VersionInfo.FileName -in $deleteSet -or $paramFile.VersionInfo.FileName -in ($deleteSet | Resolve-Path).Path) {
                                 Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $paramFile.VersionInfo.FileName
                                 continue
                             }

--- a/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
+++ b/src/internal/functions/ConvertFrom-AzOpsBicepTemplate.ps1
@@ -48,7 +48,7 @@
     process {
         if ($CompareDeploymentToDeletion) {
             # Avoid adding files destined for deletion to a deployment list
-            if ($BicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
+            if ($BicepTemplatePath -in $deleteSet -or $BicepTemplatePath -in ($deleteSet | Resolve-Path).Path) {
                 Write-AzOpsMessage -LogLevel Debug -LogString 'ConvertFrom-AzOpsBicepTemplate.Resolve.DeployDeletionOverlap' -LogStringValues $BicepTemplatePath
                 continue
             }
@@ -79,7 +79,7 @@
             }
             if ($CompareDeploymentToDeletion) {
                 # Avoid adding files destined for deletion to a deployment list
-                if ($bicepParametersPath -in $deleteSet) {
+                if ($bicepParametersPath -in $deleteSet -or $bicepParametersPath -in ($deleteSet | Resolve-Path).Path) {
                     Write-AzOpsMessage -LogLevel Debug -LogString 'ConvertFrom-AzOpsBicepTemplate.Resolve.DeployDeletionOverlap' -LogStringValues $bicepParametersPath
                     $skipParameters = $true
                 }

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -51,6 +51,7 @@
     'AzOpsScope.InitializeMemberVariablesFromFile.resource'                         = 'Determine scope based on ResourceType {0} and Resource Name {1}' # ResourceType and #Resource Name
     'AzOpsScope.ChildResource.InitializeMemberVariables'                            = 'Determine scope of Child Resource based on ResourceType {0}, Resource Name {1} and Parent ResourceID {2}' # ResourceType, Resource Name, Parent ResourceId
 
+    'ConvertFrom-AzOpsBicepTemplate.Resolve.DeployDeletionOverlap'                  = 'The file: {0} is targeted for deletion, skipping deployment file association' #
     'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate'                   = 'Converting Bicep template ({0}) to ARM Template JSON ({1})' # $BicepTemplatePath, $transpiledTemplatePath
     'ConvertFrom-AzOpsBicepTemplate.Resolve.ConvertBicepTemplate.Error'             = 'Failed to convert Bicep template ({0}) to ARM Template JSON' # $BicepTemplatePath
     'ConvertFrom-AzOpsBicepTemplate.Resolve.BicepParam'                             = 'Determine if Bicep template ({0}) has a bicepparam file at ({1})' # $BicepTemplatePath, $bicepParametersPath
@@ -210,6 +211,7 @@
     'Invoke-AzOpsPush.Dependency.Missing'                                           = 'Missing resource dependency for successfull deletion. Error exiting runtime.'
     'Invoke-AzOpsPush.DeploymentList.NotFound'                                      = 'Expecting deploymentList object, it was not found. Error exiting runtime.'
     'Invoke-AzOpsPush.Duration'                                                     = 'AzOps Push completed in {0}' # $stopWatch.Elapsed
+    'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap'                                = 'The file: {0} is targeted for deletion, skipping deployment file association' #
     'Invoke-AzOpsPush.Resolve.FoundTemplate'                                        = 'Found template {1} for parameters {0}' # $FilePath, $templatePath
     'Invoke-AzOpsPush.Resolve.FoundBicepTemplate'                                   = 'Found Bicep template {1} for parameters {0}' # $FilePath, $bicepTemplatePath
     'Invoke-AzOpsPush.Resolve.FromMainTemplate'                                     = 'Determining template from main template file: {0}' # $mainTemplateItem.FullName


### PR DESCRIPTION
# Overview/Summary

This PR fixes #879 and similar patterns.

With this changed logic the module will check that whenever deployment jobs are constructed example: `baseTemplate` + `parameterTemplate` it will check that neither file is being deleted in the same push to the module. If there in an overlap the file targeted for deletion will be skipped when constructing deployment jobs.

Without this logic the module based on its current order of processing would unintentionally first re-process (deploy) the deleted file before proceeding with deletion.

## This PR fixes/adds/changes/removes

1. Changes `Invoke-AzOpsPush.ps1`
2. Changes `ConvertFrom-AzOpsBicepTemplate.ps1`
3. Changes `Strings.psd1`

### Breaking Changes

N/A

## Testing Evidence

Tests have been performed with the following combinations using both `.json, parameters.json, bicep, bicepparams`:

- Changes to `baseTemplate` and removal of `parameterTemplate`
- Changes to `parameterTemplate` and removal of `baseTemplate`

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
