### PR TITLE
Correctly resolve template file from parameter files when suffix appears multiple times in path

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -167,8 +167,8 @@
                     { $_.EndsWith('.parameters.json') } {
                         if ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true -and $fileItem.FullName.Split('.')[-3] -match $(Get-PSFConfigValue -FullName 'AzOps.Core.MultipleTemplateParameterFileSuffix').Replace('.','')) {
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $FilePath
-                            $templatePath = $fileItem.FullName -replace (".$($fileItem.FullName.Split('.')[-3])"), '' -replace '\.parameters.json', '.json'
-                            $bicepTemplatePath = $fileItem.FullName -replace (".$($fileItem.FullName.Split('.')[-3])"), '' -replace '.parameters.json', '.bicep'
+                            $templatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters.json$", '.json'
+                            $bicepTemplatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters.json$", '.bicep'
                         }
                         else {
                             $templatePath = $fileItem.FullName -replace '\.parameters.json', (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')
@@ -210,7 +210,7 @@
                     { $_.EndsWith('.bicepparam') } {
                         if ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true -and $fileItem.FullName.Split('.')[-2] -match $(Get-PSFConfigValue -FullName 'AzOps.Core.MultipleTemplateParameterFileSuffix').Replace('.','')) {
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $FilePath
-                            $bicepTemplatePath = $fileItem.FullName -replace (".$($fileItem.FullName.Split('.')[-2])"), '' -replace '\.bicepparam', '.bicep'
+                            $bicepTemplatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-2])\.bicepparam$", '.bicep'
                         }
                         else {
                             $bicepTemplatePath = $fileItem.FullName -replace '\.bicepparam', '.bicep'

--- a/src/tests/integration/Repository.Tests.ps1
+++ b/src/tests/integration/Repository.Tests.ps1
@@ -1167,6 +1167,22 @@ Describe "Repository" {
         }
         #endregion
 
+        #region Bicep multiple parameter files with change, suffix appears multiple times in the path of the associated template
+        It "Deploy Bicep base template with parameter files where suffix appears multiple times in path" {
+            Set-PSFConfig -FullName AzOps.Core.AllowMultipleTemplateParameterFiles -Value $true
+            Set-PSFConfig -FullName AzOps.Core.MultipleTemplateParameterFileSuffix -Value ".\\w+"
+            $script:bicepRepeatSuffixPath = Get-ChildItem -Path "$($global:testRoot)/templates/rtsuffix0102*" | Copy-Item -Destination $script:resourceGroupDirectory -PassThru -Force
+            $changeSet = @(
+                "A`t$($script:bicepRepeatSuffixPath.FullName[0])",
+                "A`t$($script:bicepRepeatSuffixPath.FullName[1])"
+            )
+            {Invoke-AzOpsPush -ChangeSet $changeSet} | Should -Not -Throw
+            Start-Sleep -Seconds 5
+            $script:bicepRepeatSuffixPathDeployment = Get-AzResource -ResourceGroupName $($script:resourceGroup).ResourceGroupName -ResourceType 'Microsoft.Network/routeTables'  | Where-Object {$_.name -like "rtsuffix*"}
+            $script:bicepRepeatSuffixPathDeployment.Count | Should -Be 2
+        }
+        #endregion
+
         #region Bicep base template with no 1-1 parameter file and AllowMultipleTemplateParameterFile set to true Test should not deploy
         It "Try deployment of Bicep base template with missing defaultValue parameter with no 1-1 parameter file and AllowMultipleTemplateParameterFile set to true, Test should not deploy and exit gracefully" {
             Set-PSFConfig -FullName AzOps.Core.AllowMultipleTemplateParameterFiles -Value $true

--- a/src/tests/templates/rtsuffix.0102.02.parameters.json
+++ b/src/tests/templates/rtsuffix.0102.02.parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "rtsuffix02"
+    }
+  }
+}

--- a/src/tests/templates/rtsuffix0102.01.bicepparam
+++ b/src/tests/templates/rtsuffix0102.01.bicepparam
@@ -1,0 +1,3 @@
+using 'rtsuffix0102.bicep'
+
+param name = 'rtsuffix01'

--- a/src/tests/templates/rtsuffix0102.bicep
+++ b/src/tests/templates/rtsuffix0102.bicep
@@ -1,0 +1,12 @@
+param name string
+param location string = resourceGroup().location
+
+resource symbolicname 'Microsoft.Network/routeTables@2023-04-01' = {
+  name: name
+  location: location
+  properties: {
+    disableBgpRoutePropagation: false
+    routes: [
+    ]
+  }
+}


### PR DESCRIPTION
# Overview/Summary

Proposes to close #884

Currently, when AzOps resolves a template file from a parameter file, it uses two replace operations, one of which matches against the regex wildcard character `.`, rather than the literal character period (`\.`). Furthermore, by using two separate replace operations, the code misses a series of edge cases.

Consider a template file named `templatexabc.xabc.bicep` and a valid parameter file `templatexabc.xabc.xabc.bicepparam`. After performing the two replace operations, we are left with a template file name `templat.bicep` which doesn't exist.

## This PR fixes/adds/changes/removes

1. Changes how template file names are resolved from parameter files by ensuring that the suffix is matched at most once at the end of the parameter file name.

### Breaking Changes

1. This could _theoretically_ break deployment for someone who relies on the suffix to be matched multiple times in the template path, but I don't think that was ever intended behaviour.

Let me know if this is an issue. I can modify the PR to maintain the two separate replace operations and simply escape the period `.` in the regular expression to solve the first half of #884. That would be sufficient for my team. Let me also know if we need to change the documentation to make the behaviour of the suffix clearer.

## Testing Evidence

I added a test case to `src/tests/integration/Repository.Tests.ps1`. Haven't been able to run it yet, but I would expect it to work.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
