### PR TITLE
Fix Duplicate conflicting deployments with DeployAllMultipleTemplateParameterFiles

### DIFF
--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -158,7 +158,7 @@
             #region Case: Parameters File
             if (($fileItem.Name.EndsWith('.parameters.json')) -or ($fileItem.Name.EndsWith('.bicepparam'))) {
                 $result.TemplateParameterFilePath = $fileItem.FullName
-                $deploymentName = $fileItem.Name -replace (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix'), '' -replace ' ', '_' -replace '\.bicepparam', ''
+                $deploymentName = $fileItem.Name -replace "\.parameters\$(Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')$", '' -replace ' ', '_' -replace '\.bicepparam$', ''
                 if ($deploymentName.Length -gt 53) { $deploymentName = $deploymentName.SubString(0, 53) }
                 $result.DeploymentName = 'AzOps-{0}-{1}' -f $deploymentName, $deploymentRegionId
 
@@ -167,12 +167,12 @@
                     { $_.EndsWith('.parameters.json') } {
                         if ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true -and $fileItem.FullName.Split('.')[-3] -match $(Get-PSFConfigValue -FullName 'AzOps.Core.MultipleTemplateParameterFileSuffix').Replace('.','')) {
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $FilePath
-                            $templatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters.json$", '.json'
-                            $bicepTemplatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters.json$", '.bicep'
+                            $templatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters\.json$", '.json'
+                            $bicepTemplatePath = $fileItem.FullName -replace "\.$($fileItem.FullName.Split('.')[-3])\.parameters\.json$", '.bicep'
                         }
                         else {
-                            $templatePath = $fileItem.FullName -replace '\.parameters.json$', (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')
-                            $bicepTemplatePath = $fileItem.FullName -replace '\.parameters.json$', '.bicep'
+                            $templatePath = $fileItem.FullName -replace '\.parameters\.json$', (Get-PSFConfigValue -FullName 'AzOps.Core.TemplateParameterFileSuffix')
+                            $bicepTemplatePath = $fileItem.FullName -replace '\.parameters\.json$', '.bicep'
                         }
                         if (Test-Path $templatePath) {
                             if ($CompareDeploymentToDeletion) {
@@ -299,17 +299,21 @@
                 if ($paramFileList) {
                     $multiResult = @()
                     foreach ($paramFile in $paramFileList) {
-                        if ($CompareDeploymentToDeletion) {
-                            # Avoid adding files destined for deletion to a deployment list
-                            if ($paramFile.VersionInfo.FileName -in $deleteSet -or $paramFile.VersionInfo.FileName -in ($deleteSet | Resolve-Path).Path) {
-                                Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $paramFile.VersionInfo.FileName
-                                continue
+                        # Check if the parameter file's name matches the expected pattern
+                        $escapedBaseName = $fileItem.BaseName -replace '\.', '\.'
+                        if ($paramFile.BaseName -match "^$escapedBaseName(\$(Get-PSFConfigValue -FullName 'AzOps.Core.MultipleTemplateParameterFileSuffix'))") {
+                            if ($CompareDeploymentToDeletion) {
+                                # Avoid adding files destined for deletion to a deployment list
+                                if ($paramFile.VersionInfo.FileName -in $deleteSet -or $paramFile.VersionInfo.FileName -in ($deleteSet | Resolve-Path).Path) {
+                                    Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.DeployDeletionOverlap' -LogStringValues $paramFile.VersionInfo.FileName
+                                    continue
+                                }
                             }
-                        }
-                        # Process possible parameter files for template equivalent
-                        if (($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-3]) -or ($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-4])) {
-                            Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $paramFile.FullName
-                            $multiResult += Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $paramFile -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
+                            # Process parameter files for template equivalent
+                            if (($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-3]) -or ($fileItem.FullName.Split('.')[-2] -eq $paramFile.FullName.Split('.')[-4])) {
+                                Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.MultipleTemplateParameterFile' -LogStringValues $paramFile.FullName
+                                $multiResult += Resolve-ArmFileAssociation -ScopeObject $scopeObject -FilePath $paramFile -AzOpsMainTemplate $AzOpsMainTemplate -ConvertedTemplate $ConvertedTemplate -ConvertedParameter $ConvertedParameter -CompareDeploymentToDeletion:$CompareDeploymentToDeletion
+                            }
                         }
                     }
                     if ($multiResult) {
@@ -318,20 +322,16 @@
                     }
                     else {
                         Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterNotFound' -LogStringValues $FilePath, $parameterPath
+                        if (-not (Test-TemplateDefaultParameters -FilePath $FilePath)) {
+                            continue
+                        }
                     }
-
                 }
             }
             else {
                 Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterNotFound' -LogStringValues $FilePath, $parameterPath
                 if ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true) {
-                    # Check for template parameters without defaultValue
-                    $defaultValueContent = Get-Content $FilePath
-                    $missingDefaultParam = $defaultValueContent | jq '.parameters | with_entries(select(.value.defaultValue == null))' | ConvertFrom-Json -AsHashtable
-                    if ($missingDefaultParam.Count -ge 1) {
-                        # Skip template deployment when template parameters without defaultValue are found and no parameter file identified
-                        $missingString = foreach ($item in $missingDefaultParam.Keys.GetEnumerator()) {"$item,"}
-                        Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.NotFoundParamFileDefaultValue' -LogStringValues $FilePath, ($missingString | Out-String -NoNewline)
+                    if (-not (Test-TemplateDefaultParameters -FilePath $FilePath)) {
                         continue
                     }
                 }
@@ -343,6 +343,27 @@
 
             $result
             #endregion Case: Template File
+        }
+        function Test-TemplateDefaultParameters {
+            param(
+                [string]$FilePath
+            )
+
+            # Read the template file
+            $defaultValueContent = Get-Content $FilePath
+            # Check for parameters without a default value using jq
+            $missingDefaultParam = $defaultValueContent | jq '.parameters | with_entries(select(.value.defaultValue == null))' | ConvertFrom-Json -AsHashtable
+            if ($missingDefaultParam.Count -ge 1) {
+                # Skip template deployment when template parameters without defaultValue are found and no parameter file identified
+                $missingString = foreach ($item in $missingDefaultParam.Keys.GetEnumerator()) {"$item,"}
+                # Log a debug message with the missing parameters
+                Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.NotFoundParamFileDefaultValue' -LogStringValues $FilePath, ($missingString | Out-String -NoNewline)
+                # Missing default value were found
+                return $false
+            } else {
+                # Default values found
+                return $true
+            }
         }
         #endregion Utility Functions
 

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -322,7 +322,7 @@
                     }
                     else {
                         Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterNotFound' -LogStringValues $FilePath, $parameterPath
-                        if (-not (Test-TemplateDefaultParameters -FilePath $FilePath)) {
+                        if (-not (Test-TemplateDefaultParameter -FilePath $FilePath)) {
                             continue
                         }
                     }
@@ -331,7 +331,7 @@
             else {
                 Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Resolve.ParameterNotFound' -LogStringValues $FilePath, $parameterPath
                 if ((Get-PSFConfigValue -FullName 'AzOps.Core.AllowMultipleTemplateParameterFiles') -eq $true) {
-                    if (-not (Test-TemplateDefaultParameters -FilePath $FilePath)) {
+                    if (-not (Test-TemplateDefaultParameter -FilePath $FilePath)) {
                         continue
                     }
                 }
@@ -344,7 +344,7 @@
             $result
             #endregion Case: Template File
         }
-        function Test-TemplateDefaultParameters {
+        function Test-TemplateDefaultParameter {
             param(
                 [string]$FilePath
             )

--- a/src/tests/templates/decoy.westeurope.bicep
+++ b/src/tests/templates/decoy.westeurope.bicep
@@ -1,0 +1,12 @@
+param name string
+param location string = resourceGroup().location
+
+resource symbolicname 'Microsoft.Network/routeTables@2023-04-01' = {
+  name: name
+  location: location
+  properties: {
+    disableBgpRoutePropagation: false
+    routes: [
+    ]
+  }
+}

--- a/src/tests/templates/decoy.westeurope.x123.parameters.json
+++ b/src/tests/templates/decoy.westeurope.x123.parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "decoywex123"
+    }
+  }
+}

--- a/src/tests/templates/deployallrt.westeurope.bicep
+++ b/src/tests/templates/deployallrt.westeurope.bicep
@@ -1,0 +1,12 @@
+param name string
+param location string = resourceGroup().location
+
+resource symbolicname 'Microsoft.Network/routeTables@2023-04-01' = {
+  name: name
+  location: location
+  properties: {
+    disableBgpRoutePropagation: false
+    routes: [
+    ]
+  }
+}

--- a/src/tests/templates/deployallrt.westeurope.x123.parameters.json
+++ b/src/tests/templates/deployallrt.westeurope.x123.parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "value": "deployallrtwex123"
+    }
+  }
+}

--- a/src/tests/templates/deployallrt.westeurope.xabc.bicepparam
+++ b/src/tests/templates/deployallrt.westeurope.xabc.bicepparam
@@ -1,0 +1,3 @@
+using './deployallrt.westeurope.bicep'
+
+param name = toLower('deployallrtwexabc')

--- a/src/tests/templates/deployallrt2.westeurope.bicep
+++ b/src/tests/templates/deployallrt2.westeurope.bicep
@@ -1,0 +1,12 @@
+param name string = 'deployallrt2wex123'
+param location string = resourceGroup().location
+
+resource symbolicname 'Microsoft.Network/routeTables@2023-04-01' = {
+  name: name
+  location: location
+  properties: {
+    disableBgpRoutePropagation: false
+    routes: [
+    ]
+  }
+}


### PR DESCRIPTION
# Overview/Summary

This PR changes two key pieces to fix #886 and avoid incorrect recursive parameter discovery.

1. Adjusts how the `$deploymentName` is derived at run-time. Ensuring that if the deployment job que contains overlapping deployments, we only process it once when they have matching deployment name and files.
    1. Addressing #886
2. During recursive parameter discovery there was a possibility that a un-related file pair would have been discovered and queued for processing. This is not the intent so a step in the recursive process has been added to regex match the base name of any discovered files prior to any further processing.

## This PR fixes/adds/changes/removes

1. Changes `Invoke-AzOpsPush.ps1`
4. Changes `Repository.Tests.ps1`
5. Adds `decoy.westeurope.bicep`
6. Adds `decoy.westeurope.x123.parameters.json`
7. Adds `deployallrt.westeurope.bicep`
8. Adds `deployallrt.westeurope.x123.parameters.json`
9. Adds `deployallrt.westeurope.xabc.bicepparam`
10. Adds `deployallrt2.westeurope.bicep`

### Breaking Changes

1. N/A

## Testing Evidence

The logic has been tested according to the issue and an automated test has been added.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
