### PR TITLE
Fix Resource Existence Validation Error Logic

### DIFF
--- a/src/internal/functions/Get-AzOpsResource.ps1
+++ b/src/internal/functions/Get-AzOpsResource.ps1
@@ -20,32 +20,38 @@
 
     process {
         Set-AzOpsContext -ScopeObject $ScopeObject
-        switch ($ScopeObject.Resource) {
-            # Check if the resource exist
-            'locks' {
-                $resource = Get-AzResourceLock -Scope "/subscriptions/$($ScopeObject.Subscription)" -ErrorAction SilentlyContinue | Where-Object { $_.ResourceID -eq $ScopeObject.Scope }
+        try {
+            switch ($ScopeObject.Resource) {
+                # Check if the resource exist
+                'locks' {
+                    $resource = Get-AzResourceLock -Scope "/subscriptions/$($ScopeObject.Subscription)" -ErrorAction SilentlyContinue | Where-Object { $_.ResourceID -eq $ScopeObject.Scope }
+                }
+                'policyAssignments' {
+                    $resource = Get-AzPolicyAssignment -Id $scopeObject.Scope -ErrorAction SilentlyContinue
+                }
+                'policyDefinitions' {
+                    $resource = Get-AzPolicyDefinition -Id $scopeObject.Scope -ErrorAction SilentlyContinue
+                }
+                'policyExemptions' {
+                    $resource = Get-AzPolicyExemption -Id $scopeObject.Scope -ErrorAction SilentlyContinue
+                }
+                'policySetDefinitions' {
+                    $resource = Get-AzPolicySetDefinition -Id $scopeObject.Scope -ErrorAction SilentlyContinue
+                }
+                'roleAssignments' {
+                    $resource = Invoke-AzRestMethod -Path "$($scopeObject.Scope)?api-version=2022-04-01" | Where-Object { $_.StatusCode -eq 200 }
+                }
+                'resourceGroups' {
+                    $resource = Get-AzResourceGroup -Id $scopeObject.Scope -ErrorAction SilentlyContinue
+                }
+                default {
+                    $resource = Get-AzResource -ResourceId $ScopeObject.Scope -ErrorAction SilentlyContinue
+                }
             }
-            'policyAssignments' {
-                $resource = Get-AzPolicyAssignment -Id $scopeObject.Scope -ErrorAction SilentlyContinue
-            }
-            'policyDefinitions' {
-                $resource = Get-AzPolicyDefinition -Id $scopeObject.Scope -ErrorAction SilentlyContinue
-            }
-            'policyExemptions' {
-                $resource = Get-AzPolicyExemption -Id $scopeObject.Scope -ErrorAction SilentlyContinue
-            }
-            'policySetDefinitions' {
-                $resource = Get-AzPolicySetDefinition -Id $scopeObject.Scope -ErrorAction SilentlyContinue
-            }
-            'roleAssignments' {
-                $resource = Invoke-AzRestMethod -Path "$($scopeObject.Scope)?api-version=2022-04-01" | Where-Object { $_.StatusCode -eq 200 }
-            }
-            'resourceGroups' {
-                $resource = Get-AzResourceGroup -Id $scopeObject.Scope -ErrorAction SilentlyContinue
-            }
-            default {
-                $resource = Get-AzResource -ResourceId $ScopeObject.Scope -ErrorAction SilentlyContinue
-            }
+        }
+        catch {
+            Write-AzOpsMessage -LogLevel InternalComment -LogString 'Get-AzOpsResource.Failed' -LogStringValues $_
+            return
         }
         if ($resource) {
             return $resource

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -98,6 +98,8 @@
     'Get-AzOpsPolicyExemption.ResourceGroup'                                        = 'Retrieving Policy Exemption for Resource Group {0}' # $ScopeObject.ResourceGroup
     'Get-AzOpsPolicyExemption.Subscription'                                         = 'Retrieving Policy Exemption for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription
 
+    'Get-AzOpsResource.Failed'                                                      = 'Failed retrieving resource with error: {0}' # $_
+
     'Get-AzOpsResourceLock.ResourceGroup'                                           = 'Retrieving Resource Locks for Resource Group {0}' # $ScopeObject.ResourceGroup
     'Get-AzOpsResourceLock.Failed'                                                  = 'Failed retrieving Resource Locks {0}' # $_
     'Get-AzOpsResourceLock.Subscription'                                            = 'Retrieving Resource Locks for Subscription {0} ({1})' # $ScopeObject.SubscriptionDisplayName, $ScopeObject.Subscription


### PR DESCRIPTION
# Overview/Summary

This PR adds `Try` and `Catch` logic  to `Get-AzOpsResource.ps1` to manage underlying `Az.PowerShell` changes in error handling.

Without this code change the module can throw during custom resource deletion `$scriptCmd = {& $wrappedCmd @PSBoundParameters}` due to -ErrorAction handling changes in depended modules.

## This PR fixes/adds/changes/removes

1. Changes `Get-AzOpsResource.ps1`
2. Changes `Strings.psd1`

### Breaking Changes

1. N/A

## Testing Evidence

Deployment and deletion of custom resources have been tested.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
