### PR TITLE
Update ApiVersion Logic to compare RP with Graph

### DIFF
--- a/docs/wiki/Frequently-Asked-Questions.md
+++ b/docs/wiki/Frequently-Asked-Questions.md
@@ -10,7 +10,7 @@ This article answers frequently asked questions relating to AzOps.
   - [Management groups not showing up in repository](#management-groups-not-showing-up-in-repository)
   - [Push fail with deployment already exists in location error](#push-fail-with-deployment-already-exists-in-location-error)
   - [Does AzOps use temporary files](#does-azops-use-temporary-files)
-  - [How does AzOps Pull set Api version](#how-does-azops-pull-set-api-version)
+  - [How does AzOps Pull set API version](#how-does-azops-pull-set-api-version)
   - [Pull fail with active pull request already exists error](#pull-fail-with-active-pull-request-already-exists-error)
   - [Discovery scenarios and settings](#discovery-scenarios-and-settings)
     - [**I want to discover all resources across all resource groups in one specific subscription**](#i-want-to-discover-all-resources-across-all-resource-groups-in-one-specific-subscription)
@@ -72,22 +72,22 @@ AzOps utilizes the temporary directory for storing temporary information either 
 
 >Due to the different usage patterns of temporary files they are either created and deleted during module invocation or created and left for further processing at a later stage. As a part of AzOps invocation the initialize procedure looks for lingering temporary files (e.g. `OUTPUT.md / OUTPUT.json`) and removes them to ensure a clean execution.
 
-## How does AzOps Pull set Api version
+## How does AzOps Pull set API version
 
-When AzOps performs a Pull it gathers resource information and performs several formatting steps to ensure a deployable template is generated. During these steps AzOps dynamically determines the Api version of each resource.
+When AzOps performs a Pull it gathers resource information and performs several formatting steps to ensure a deployable template is generated. During these steps AzOps dynamically determines the API version of each resource.
 
 To make this determination the following information and logic is utilized:
 
 First AzOps performs:
-- `Get-AzResourceProvider -ListAvailable` gathers available resource providers and their api versions from ARM.
+- `Get-AzResourceProvider -ListAvailable` gathers available resource providers and their API versions from ARM.
 
 Based on this information AzOps derives ga and preview versions from `Get-AzResourceProvider` and prefers the latest ga version, unless there is no ga version then a preview version is considered.
 
->Due to that api versions gathered at this step could be versions that are being rolled out and might not be available everywhere AzOps corroborate this with additional data in the next step to avoid inconsistencies as new api versions are rolled out.
+>Due to that API versions gathered at this step could be versions that are being rolled out and might not be available everywhere AzOps corroborate this with additional data in the next step to avoid inconsistencies as new API versions are rolled out.
 
-- `Search-AzGraph -UseTenantScope -Query $Query -AllowPartialScope` gathers available api version from Azure Resource Graph.
+- `Search-AzGraph -UseTenantScope -Query $Query -AllowPartialScope` gathers available API version from Azure Resource Graph.
 
-Based on this additional datapoint AzOps derives if the api version from `Get-AzResourceProvider` and `Search-AzGraph` differ while the `Search-AzGraph` version exists in `Get-AzResourceProvider` and overrides the `Get-AzResourceProvider` version if they don’t match.
+Based on this additional datapoint AzOps derives if the API version from `Get-AzResourceProvider` and `Search-AzGraph` differ while the `Search-AzGraph` version exists in `Get-AzResourceProvider` and overrides the `Get-AzResourceProvider` version if they don’t match.
 
 ## Pull fail with active pull request already exists error
 

--- a/src/functions/Initialize-AzOpsEnvironment.ps1
+++ b/src/functions/Initialize-AzOpsEnvironment.ps1
@@ -110,6 +110,8 @@
         }
         $script:AzOpsSubscriptions = Get-AzOpsSubscription -ExcludedOffers $ExcludedSubOffer -ExcludedStates $ExcludedSubState -TenantId $tenantId
         $script:AzOpsResourceProvider = Get-AzResourceProvider -ListAvailable
+        $query = "Resources | project type, apiVersion | union (PolicyResources | project type, apiVersion) | union (ResourceContainers | project type, apiVersion) | where isnotnull(apiVersion) | summarize apiVersion=max(apiVersion) by type | order by type asc"
+        $script:AzOpsGraphResourceProvider = Search-AzOpsAzGraph -UseTenantScope -Query $query
         $script:AzOpsAzManagementGroup = @()
         $script:AzOpsPartialRoot = @()
         #endregion Initialize & Prepare

--- a/src/functions/Invoke-AzOpsPush.ps1
+++ b/src/functions/Invoke-AzOpsPush.ps1
@@ -559,13 +559,14 @@
                             Write-AzOpsMessage -LogLevel Debug -LogString 'Invoke-AzOpsPush.Deployment.Parallel' -LogStringValues $deployment.TemplateFilePath, $targets.Count
                             # Prepare Input Data for parallel processing
                             $runspaceData = @{
-                                AzOpsPath                       = "$($script:ModuleRoot)\AzOps.psd1"
-                                StatePath                       = $StatePath
-                                WhatIfPreference                = $WhatIfPreference
-                                runspace_AzOpsAzManagementGroup = $script:AzOpsAzManagementGroup
-                                runspace_AzOpsSubscriptions     = $script:AzOpsSubscriptions
-                                runspace_AzOpsPartialRoot       = $script:AzOpsPartialRoot
-                                runspace_AzOpsResourceProvider  = $script:AzOpsResourceProvider
+                                AzOpsPath                            = "$($script:ModuleRoot)\AzOps.psd1"
+                                StatePath                            = $StatePath
+                                WhatIfPreference                     = $WhatIfPreference
+                                runspace_AzOpsAzManagementGroup      = $script:AzOpsAzManagementGroup
+                                runspace_AzOpsSubscriptions          = $script:AzOpsSubscriptions
+                                runspace_AzOpsPartialRoot            = $script:AzOpsPartialRoot
+                                runspace_AzOpsResourceProvider       = $script:AzOpsResourceProvider
+                                runspace_AzOpsGraphResourceProvider  = $script:AzOpsGraphResourceProvider
                             }
                             # Pass deployment targets for parallel processing and output deployment result for later
                             $deploymentResult += $targets | Foreach-Object -ThrottleLimit (Get-PSFConfigValue -FullName 'AzOps.Core.ThrottleLimit') -Parallel {
@@ -580,6 +581,7 @@
                                     $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                                     $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                                     $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                                    $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                                 }
 
                                 & $azOps {

--- a/src/internal/functions/ConvertTo-AzOpsState.ps1
+++ b/src/internal/functions/ConvertTo-AzOpsState.ps1
@@ -234,6 +234,13 @@
                         } else {
                             $apiVersion = $gaApiVersion | Select-Object -First 1
                         }
+                        # Compare Providers - List API version to Graph API version
+                        $graphApiVersion = ($script:AzOpsGraphResourceProvider | Where-Object { $_.type -eq "$providerNamespace/$resourceApiTypeName" })?.apiVersion
+                        if ($null -ne $graphApiVersion -and $apiVersion -ne $graphApiVersion) {
+                            # If the Graph API version is not null and differs from the current API version, update the API version
+                            Write-AzOpsMessage -LogLevel Debug -LogString 'ConvertTo-AzOpsState.GenerateTemplate.ApiVersionGraphOverride' -LogStringValues $apiVersion, $graphApiVersion, $resourceType
+                            $apiVersion = $graphApiVersion
+                        }
                         Write-AzOpsMessage -LogLevel Debug -LogString 'ConvertTo-AzOpsState.GenerateTemplate.ApiVersion' -LogStringValues $resourceType, $apiVersion
                         $object.resources[0].apiVersion = $apiVersion
                         $object.resources[0].type = $resourceType

--- a/src/internal/functions/ConvertTo-AzOpsState.ps1
+++ b/src/internal/functions/ConvertTo-AzOpsState.ps1
@@ -236,8 +236,8 @@
                         }
                         # Compare Providers - List API version to Graph API version
                         $graphApiVersion = ($script:AzOpsGraphResourceProvider | Where-Object { $_.type -eq "$providerNamespace/$resourceApiTypeName" })?.apiVersion
-                        if ($null -ne $graphApiVersion -and $apiVersion -ne $graphApiVersion) {
-                            # If the Graph API version is not null and differs from the current API version, update the API version
+                        if ($null -ne $graphApiVersion -and $apiVersion -ne $graphApiVersion -and $graphApiVersion -in $apiVersions) {
+                            # If the Graph API version is not null and differs from the current API version while also existing in $apiVersions, update the API version
                             Write-AzOpsMessage -LogLevel Debug -LogString 'ConvertTo-AzOpsState.GenerateTemplate.ApiVersionGraphOverride' -LogStringValues $apiVersion, $graphApiVersion, $resourceType
                             $apiVersion = $graphApiVersion
                         }

--- a/src/internal/functions/Get-AzOpsResourceDefinition.ps1
+++ b/src/internal/functions/Get-AzOpsResourceDefinition.ps1
@@ -103,14 +103,15 @@
         $maxRetryCount = 3
         # Prepare Input Data for parallel processing
         $runspaceData = @{
-            AzOpsPath                       = "$($script:ModuleRoot)\AzOps.psd1"
-            StatePath                       = $StatePath
-            runspace_AzOpsAzManagementGroup = $script:AzOpsAzManagementGroup
-            runspace_AzOpsSubscriptions     = $script:AzOpsSubscriptions
-            runspace_AzOpsPartialRoot       = $script:AzOpsPartialRoot
-            runspace_AzOpsResourceProvider  = $script:AzOpsResourceProvider
-            BackoffMultiplier               = $backoffMultiplier
-            MaxRetryCount                   = $maxRetryCount
+            AzOpsPath                            = "$($script:ModuleRoot)\AzOps.psd1"
+            StatePath                            = $StatePath
+            runspace_AzOpsAzManagementGroup      = $script:AzOpsAzManagementGroup
+            runspace_AzOpsSubscriptions          = $script:AzOpsSubscriptions
+            runspace_AzOpsPartialRoot            = $script:AzOpsPartialRoot
+            runspace_AzOpsResourceProvider       = $script:AzOpsResourceProvider
+            runspace_AzOpsGraphResourceProvider  = $script:AzOpsGraphResourceProvider
+            BackoffMultiplier                    = $backoffMultiplier
+            MaxRetryCount                        = $maxRetryCount
         }
     }
 
@@ -151,6 +152,7 @@
                             $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                             $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                             $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                            $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                         }
                         # Process Privileged Identity Management resources and Roles at managementGroup scope
                         if ((-not $using:SkipPim) -or (-not $using:SkipRole)) {
@@ -189,6 +191,7 @@
                     $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                     $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                     $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                    $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                 }
                 # Process Privileged Identity Management resources, Locks and Roles at subscription scope
                 if ((-not $using:SkipPim) -or (-not $using:SkipLock) -or (-not $using:SkipRole)) {
@@ -247,6 +250,7 @@
                         $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                         $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                         $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                        $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                     }
                     # Create Resource Group in file system
                     & $azOps {
@@ -336,6 +340,7 @@
                         $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                         $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                         $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                        $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                     }
                     $context = Get-AzContext
                     $context.Subscription.Id = $resource.subscriptionId

--- a/src/internal/functions/Save-AzOpsManagementGroupChild.ps1
+++ b/src/internal/functions/Save-AzOpsManagementGroupChild.ps1
@@ -113,12 +113,13 @@
         if ($subscriptions) {
             # Prepare Input Data for parallel processing
             $runspaceData = @{
-                AzOpsPath                       = "$($script:ModuleRoot)\AzOps.psd1"
-                StatePath                       = $StatePath
-                runspace_AzOpsAzManagementGroup = $script:AzOpsAzManagementGroup
-                runspace_AzOpsSubscriptions     = $script:AzOpsSubscriptions
-                runspace_AzOpsPartialRoot       = $script:AzOpsPartialRoot
-                runspace_AzOpsResourceProvider  = $script:AzOpsResourceProvider
+                AzOpsPath                            = "$($script:ModuleRoot)\AzOps.psd1"
+                StatePath                            = $StatePath
+                runspace_AzOpsAzManagementGroup      = $script:AzOpsAzManagementGroup
+                runspace_AzOpsSubscriptions          = $script:AzOpsSubscriptions
+                runspace_AzOpsPartialRoot            = $script:AzOpsPartialRoot
+                runspace_AzOpsResourceProvider       = $script:AzOpsResourceProvider
+                runspace_AzOpsGraphResourceProvider  = $script:AzOpsGraphResourceProvider
             }
             $subscriptions | Foreach-Object -ThrottleLimit (Get-PSFConfigValue -FullName 'AzOps.Core.ThrottleLimit') -Parallel {
                 $subscription = $_
@@ -132,6 +133,7 @@
                     $script:AzOpsSubscriptions = $runspaceData.runspace_AzOpsSubscriptions
                     $script:AzOpsPartialRoot = $runspaceData.runspace_AzOpsPartialRoot
                     $script:AzOpsResourceProvider = $runspaceData.runspace_AzOpsResourceProvider
+                    $script:AzOpsGraphResourceProvider = $runspaceData.runspace_AzOpsGraphResourceProvider
                 }
 
                 & $azOps {

--- a/src/localized/en-us/Strings.psd1
+++ b/src/localized/en-us/Strings.psd1
@@ -72,6 +72,7 @@
     'ConvertTo-AzOpsState.GenerateTemplate.ResourceTypeName'                        = 'Resource type: {0}' # $resourceTypeName
     'ConvertTo-AzOpsState.GenerateTemplate.ResourceApiTypeName'                     = 'Resource api type: {0}' # $resourceApiTypeName
     'ConvertTo-AzOpsState.GenerateTemplate.ApiVersion'                              = 'Determined api version: {1} for resource type name: {0}' # $resourceType, $apiVersions
+    'ConvertTo-AzOpsState.GenerateTemplate.ApiVersionGraphOverride'                 = 'Determined that AzResourceProvider api version: {0} did not match Graph api version: {1} for resource type name: {2}, overriding with Graph api version.' # $apiVersion, $graphApiVersion, $resourceType
     'ConvertTo-AzOpsState.GenerateTemplate.NoApiVersion'                            = 'Unable to determine api version from resource type name: {0}' # $resourceTypeName
     'ConvertTo-AzOpsState.GenerateTemplate.ChildResource'                           = 'Appending child resource name: {0}' # $resourceName
     'ConvertTo-AzOpsState.ObjectType.Resolved.Generic'                              = 'Unable to determine object type: {0}' # $($_.GetType())


### PR DESCRIPTION
# Overview/Summary

This PR adds logic to compare the API version returned for a Resource Provider (RP) with the API version returned by the Graph service. By doing this and overriding the RP `apiVersion` if it does not match Graph `apiVersion` while still being listed as a functional `apiVersion` by the RP ensures a consistent pull experience and fix #911.

When running module in debug mode each time an `apiVersion` override is performed the following message is emitted.
![message](https://github.com/user-attachments/assets/93bbf0ac-4266-4897-b82d-d6e529d0cdb1)


## This PR fixes/adds/changes/removes

1. Changes `Initialize-AzOpsEnvironment.ps1`
2. Changes `Invoke-AzOpsPush.ps1`
3. Changes `ConvertTo-AzOpsState.ps1`
4. Changes `Get-AzOpsResourceDefinition.ps1`
5. Changes `Save-AzOpsManagementGroupChild.ps1`
6. Changes `Strings.psd1`

### Breaking Changes

N/A

## Testing Evidence

Different performance and manual testing have been performed to ensure override functionally does not have an adverse affect.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
