### PR TITLE
Fix Regression of Role Assignment Deletion Logic

### DIFF
--- a/src/internal/functions/Remove-AzOpsDeployment.ps1
+++ b/src/internal/functions/Remove-AzOpsDeployment.ps1
@@ -283,9 +283,12 @@
                     }
                 }
                 'roleAssignments' {
-                    $resourceToDelete = (Invoke-AzRestMethod -Path "$($scopeObject.Scope)?api-version=2022-04-01" | Where-Object { $_.StatusCode -eq 200 }).Content | ConvertFrom-Json -Depth 100
-                    if ($resourceToDelete) {
-                        $dependency += Get-AzLocksDeletionDependency -resourceToDelete $resourceToDelete
+                    $response = Invoke-AzRestMethod -Path "$($scopeObject.Scope)?api-version=2022-04-01" -ErrorAction SilentlyContinue
+                    if ($response.StatusCode -eq 200) {
+                        $resourceToDelete = $response.Content | ConvertFrom-Json -Depth 100
+                        if ($resourceToDelete) {
+                            $dependency += Get-AzLocksDeletionDependency -resourceToDelete $resourceToDelete
+                        }
                     }
                 }
                 'resourceGroups' {


### PR DESCRIPTION
# Overview/Summary

This PR fixes the erroneous handling of `Microsoft.Authorization/roleAssignments` deletions that was introduced in `AzOps 2.6.5` causing validate and push to fail when the roleAssignments had been removed out of bound.

This fixes #921.

## This PR fixes/adds/changes/removes

1. Changes `Remove-AzOpsDeployment.ps1`

### Breaking Changes

N/A

## Testing Evidence

With new logic validate does not fail:
![image](https://github.com/user-attachments/assets/e8d01caa-138b-42bb-bd61-33d67bc8ee7a)
With new logic push does not fail:
![image](https://github.com/user-attachments/assets/ec478a6b-f472-4927-b666-f3e4355b88a1)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/azops/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/azops/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/azops/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
